### PR TITLE
Allow to use active model serializers

### DIFF
--- a/config/initializers/sequel_active_model_errors.rb
+++ b/config/initializers/sequel_active_model_errors.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This adds a "messages" method to Sequel::Model::Errors that behaves like
+# ActiveModelSerializers needs it.
+
+module Sequel
+  class Model
+    # The errors class of the Sequel::Model needs to be expanded by a messages
+    # method for ActiveModel::Serializer to work properly.
+    class Errors
+      # The #errors hash is already formed as we need the messages to be.
+      def messages
+        self
+      end
+    end
+  end
+end

--- a/config/initializers/sequel_active_model_serializer.rb
+++ b/config/initializers/sequel_active_model_serializer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'sequel/plugins/active_model'
+module Sequel
+  module Plugins
+    # The ActiveModelSerializer plugin makes Sequel::Model objects
+    # pass the ActiveModel::Serializer::Lint tests, which should
+    # mean full ActiveModelSerializer compliance.
+    # This plugin needs active_model to be plugged in as well.
+    # Usage:
+    #
+    #   # Make all subclasses active_model_serializer compliant
+    #   (called before loading subclasses)
+    #   Sequel::Model.plugin :active_model
+    #   Sequel::Model.plugin :active_model_serializer
+    #
+    #   # Make the Album class active_model_serializer compliant
+    #   Album.plugin :active_model
+    #   Album.plugin :active_model_serializer
+    module ActiveModelSerializer
+      # Instance methods of each model
+      module InstanceMethods
+        def serializable_hash
+          as_json
+        end
+
+        def read_attribute_for_serialization(attribute)
+          send(attribute)
+        end
+
+        def cache_key
+          "#{self.class.to_s.downcase.pluralize}/"\
+            "#{id}-#{updated_at.strftime('%Y%m%d%H%M%S%6N')}"
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/sequel_rails_compatibility.rb
+++ b/config/initializers/sequel_rails_compatibility.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Make Sequel::Model objects pass the ActiveModel::Serializer::Lint tests,
+# which should mean full ActiveModelSerializer compliance.
+#
+# The models are only compatible to ActiveModelSerializer, if they have the
+# updated_at timestamp attribute. The timestamps need to be plugged in
+# explicitly in each model.
+Sequel::Model.plugin :active_model
+Sequel::Model.plugin :active_model_serializer

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Repository, type: :model do
   end
 
   context 'validations' do
-    let(:repository) { build :repository }
     context 'name' do
       it { is_expected.to validate_presence(:name) }
       it { is_expected.to validate_length_range((3..100), :name) }
@@ -27,27 +26,28 @@ RSpec.describe Repository, type: :model do
     let(:repository) do
       create :repository, name: Faker::Lorem.words(2).join(' ')
     end
+    subject { repository }
 
     context 'on create' do
       it 'the slug is set correctly' do
-        expect(repository.slug).to eq(repository.name.parameterize)
+        expect(subject.slug).to eq(subject.name.parameterize)
       end
     end
 
     context 'on update' do
-      let!(:old_slug) { repository.slug }
+      let!(:old_slug) { subject.slug }
       before do
-        repository.name = "#{repository.name}_changed"
-        repository.save
+        subject.name = "#{subject.name}_changed"
+        subject.save
       end
 
       it 'the slug is not changed' do
-        expect(repository.slug).to eq(old_slug)
+        expect(subject.slug).to eq(old_slug)
       end
     end
 
     it 'exposes to_param correctly' do
-      expect(repository.to_param).to eq(repository.slug)
+      expect(subject.to_param).to eq(subject.slug)
     end
   end
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'shared_examples/active_model'
+require 'shared_examples/active_model_serializer'
 
 RSpec.describe Repository, type: :model do
   context 'columns' do
@@ -20,6 +22,12 @@ RSpec.describe Repository, type: :model do
       it { is_expected.to validate_unique(:slug) }
       it { is_expected.to validate_format(/\A[a-z0-9-]+\z/, :slug) }
     end
+  end
+
+  context 'compatibility' do
+    subject { build :repository, name: Faker::Lorem.words(2).join(' ') }
+    it_behaves_like 'an ActiveModel compatible object'
+    it_behaves_like 'an ActiveModelSerializer compatible object'
   end
 
   context 'slug' do

--- a/spec/shared_examples/active_model.rb
+++ b/spec/shared_examples/active_model.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# This is the RSpec formulation of ActiveModel::Lint::Tests
+RSpec.shared_examples 'an ActiveModel compatible object' do
+  describe '#to_key' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:to_key)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:to_key).arity).to eq(0)
+    end
+
+    it 'is nil for a non-persisted model' do
+      allow(subject).to receive(:persisted?).and_return(false)
+      expect(subject.to_key).to be(nil)
+    end
+  end
+
+  describe '#to_param' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:to_param)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:to_param).arity).to eq(0)
+    end
+
+    it 'is nil for a non-persisted model' do
+      allow(subject).to receive(:persisted?).and_return(false)
+      allow(subject).to receive(:to_key).and_return([1])
+      expect(subject.to_param).to be(nil)
+    end
+  end
+
+  describe '#to_partial_path' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:to_partial_path)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:to_partial_path).arity).to eq(0)
+    end
+
+    it 'is a String' do
+      expect(subject.to_partial_path).to be_a(String)
+    end
+  end
+
+  describe '#persisted?' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:persisted?)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:persisted?).arity).to eq(0)
+    end
+  end
+
+  describe '.model_name' do
+    it 'reponds to the method' do
+      expect(subject.class).to respond_to(:model_name)
+    end
+
+    it 'responds to #to_str' do
+      expect(subject.model_name).to respond_to(:to_str)
+    end
+
+    it 'responds to #human#to_str' do
+      expect(subject.model_name.human).to respond_to(:to_str)
+    end
+
+    it 'responds to #singular#to_str' do
+      expect(subject.model_name.singular).to respond_to(:to_str)
+    end
+
+    it 'responds to #plural#to_str' do
+      expect(subject.model_name.plural).to respond_to(:to_str)
+    end
+  end
+
+  describe '#model_name' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:model_name)
+    end
+
+    it "is equal to the class's model_name" do
+      expect(subject.model_name).to eq(subject.class.model_name)
+    end
+  end
+
+  describe '#errors' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:errors)
+    end
+  end
+end

--- a/spec/shared_examples/active_model_serializer.rb
+++ b/spec/shared_examples/active_model_serializer.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# This is the RSpec formulation of ActiveModel::Serializer::Lint::Tests
+RSpec.shared_examples 'an ActiveModelSerializer compatible object' do
+  describe '#serializable_hash' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:serializable_hash)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:serializable_hash).arity).to eq(0)
+    end
+
+    it 'is a Hash' do
+      expect(subject.serializable_hash).to be_a(Hash)
+    end
+  end
+
+  describe '#read_attribute_for_serialization' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:read_attribute_for_serialization)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:read_attribute_for_serialization).arity).to eq(1)
+    end
+
+    it 'is the id when called with id' do
+      expect(subject.read_attribute_for_serialization(:id)).to eq(subject.id)
+    end
+  end
+
+  describe '#as_json' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:as_json)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:as_json).arity).to eq(-1)
+    end
+
+    it 'is a Hash' do
+      expect(subject.as_json).to be_a(Hash)
+    end
+
+    it 'is a Hash when called with nil' do
+      expect(subject.as_json(nil)).to be_a(Hash)
+    end
+  end
+
+  describe '#to_json' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:to_json)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:to_json).arity).to eq(-1)
+    end
+
+    it 'is a JSON String' do
+      expect(JSON.parse(subject.to_json)).to be_a(Hash)
+    end
+
+    it 'is a JSON String when called with nil' do
+      expect(JSON.parse(subject.to_json(nil))).to be_a(Hash)
+    end
+  end
+
+  describe '#cache_key' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:cache_key)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:cache_key).arity).to eq(0)
+    end
+
+    it 'is a String' do
+      expect(subject.cache_key).to be_a(String)
+    end
+  end
+
+  describe '#updated_at' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:updated_at)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:updated_at).arity).to eq(0)
+    end
+  end
+
+  describe '#id' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:id)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:id).arity).to eq(0)
+    end
+  end
+
+  describe '.model_name' do
+    it 'reponds to the method' do
+      expect(subject.class).to respond_to(:model_name)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.class.method(:model_name).arity).to eq(0)
+    end
+
+    it 'is a ActiveModel::Name' do
+      expect(subject.class.model_name).to be_a(ActiveModel::Name)
+    end
+  end
+
+  describe '#errors' do
+    it 'reponds to the method' do
+      expect(subject).to respond_to(:errors)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.method(:errors).arity).to eq(0)
+    end
+
+    it 'is a Hash' do
+      expect(subject.errors).to be_a(Hash)
+    end
+  end
+
+  describe '.human_attribute_name' do
+    it 'reponds to the method' do
+      expect(subject.class).to respond_to(:human_attribute_name)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.class.method(:human_attribute_name).arity).to eq(-2)
+    end
+  end
+
+  describe '.lookup_ancestors' do
+    it 'reponds to the method' do
+      expect(subject.class).to respond_to(:lookup_ancestors)
+    end
+
+    it 'takes the correct number of arguments' do
+      expect(subject.class.method(:lookup_ancestors).arity).to eq(0)
+    end
+  end
+end

--- a/spec/shared_examples/active_model_serializer.rb
+++ b/spec/shared_examples/active_model_serializer.rb
@@ -128,6 +128,20 @@ RSpec.shared_examples 'an ActiveModelSerializer compatible object' do
     it 'is a Hash' do
       expect(subject.errors).to be_a(Hash)
     end
+
+    describe '#messages' do
+      it 'responds to the method' do
+        expect(subject.errors).to respond_to(:messages)
+      end
+
+      it 'takes the correct number of arguments' do
+        expect(subject.errors.method(:messages).arity).to eq(0)
+      end
+
+      it 'is a Hash' do
+        expect(subject.errors.messages).to be_a(Hash)
+      end
+    end
   end
 
   describe '.human_attribute_name' do


### PR DESCRIPTION
This pull request adds compatibility of our Sequel models to ActiveModelSerializer and simple compatibility tests that we can include in all new models. The tests follow the scheme of [ActiveModel::Serializer::Lint](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer/lint.rb).

The compatibility is added to a model by including the Sequel plugin `active_model_serializer`. This is done for the base class in an initializer. If we ever want to have a model that should not be serializable, e.g. an association model, we need to remove the initializer and plug in the compatibility module for every single serializable model.