### PR TITLE
Add rake task to recreate the database.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
 end
 
 load 'rails/tasks/statistics.rake'
+Dir.glob('lib/tasks/**/*.rake').each { |file| load file }
 
 Bundler::GemHelper.install_tasks
 APP_RAKEFILE = File.expand_path('../spec/dummy/Rakefile', __FILE__)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :db do
+  desc 'Recreate the database (drop, create, migrate)'
+  task :recreate do
+    begin
+      Rake::Task['db:drop'].invoke
+    rescue Sequel::DatabaseConnectionError => e
+      raise unless e.message =~ /database "[^"]+" does not exist/
+    end
+    Rake::Task['db:create'].invoke
+    Rake::Task['db:migrate'].invoke
+  end
+end


### PR DESCRIPTION
Adds the rake task `db:recreate` to quickly perform a `db:drop`, `db:create` and `db:migrate`.