### PR TITLE
Speed up the tests by lowering security of bcrypt.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Devise.setup do |config|
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 15. If
+  # using other encryptors, it sets how many times you want the password
+  # re-encrypted.
+  #
+  # Limiting the stretches to just one in testing will increase the performance
+  # of your test suite dramatically. However, it is STRONGLY RECOMMENDED to not
+  # use a value less than 15 in other environments.
+  config.stretches = Rails.env.test? ? 1 : 15
+end


### PR DESCRIPTION
See https://github.com/plataformatec/devise/wiki/Speed-up-your-unit-tests for more information.

The tests take now about 4 seconds instead of about 60 seconds.