### PR TITLE
Add rubinius support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ dist: trusty
 language: ruby
 
 rvm:
-  - 2.3.1
+  - 2.3.3
+  - rbx-3.69
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - postgresql
 
 addons:
-  postgresql: '9.4'
+  postgresql: '9.6'
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ notifications:
   email: false
 
 before_script:
-  - RAILS_ENV=test bin/rails db:create
-  - RAILS_ENV=test bin/rails db:migrate
+  - RAILS_ENV=test bin/rails db:recreate
 
 script:
   - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,12 @@ source 'https://rubygems.org'
 # development dependencies will be added by default to the :development group.
 gemspec
 
+group :development do
+  gem 'pry-byebug', '~> 3.4.2', platform: :mri
+  gem 'pry-stack_explorer', '~> 0.4.9.2', platform: :mri
+  gem 'pry-rescue', '~> 1.4.4', platform: :mri
+end
+
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,6 @@ PATH
       chewy (~> 0.8.4)
       devise (~> 4.2.0)
       pry (~> 0.10.4)
-      pry-byebug (~> 3.4.2)
-      pry-rescue (~> 1.4.4)
-      pry-stack_explorer (~> 0.4.9.2)
       rails (~> 5.0.1)
       sequel (~> 4.41.0)
       sequel-devise (~> 0.0.9)
@@ -234,12 +231,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.12)
+  bundler (~> 1.11)
   coveralls (~> 0.8.17)
   database_cleaner (~> 1.5.3)
   factory_girl_rails (~> 4.8.0)
   faker (~> 1.6.6)
   ontohub-models!
+  pry-byebug (~> 3.4.2)
+  pry-rescue (~> 1.4.4)
+  pry-stack_explorer (~> 0.4.9.2)
   rake (~> 12.0.0)
   rspec (~> 3.5.0)
   rspec-rails (~> 3.5.2)

--- a/lib/ontohub_models/engine.rb
+++ b/lib/ontohub_models/engine.rb
@@ -3,6 +3,7 @@
 require 'pry'
 require 'sequel-rails'
 require 'devise'
+require 'rubinius/debugger' if RUBY_ENGINE == 'rbx' && !Rails.env.production?
 
 module OntohubModels
   # The base engine class - Rails default

--- a/ontohub-models.gemspec
+++ b/ontohub-models.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sequel-devise', '~> 0.0.9'
 
   # General Development
-  s.add_development_dependency 'bundler', '~> 1.12'
+  s.add_development_dependency 'bundler', '~> 1.11'
   s.add_development_dependency 'rake', '~> 12.0.0'
 
   # Testing
@@ -53,8 +53,5 @@ Gem::Specification.new do |s|
   # We want to have these in the production environment as well in case we need
   # to debug the application:
   s.add_dependency 'pry', '~> 0.10.4'
-  s.add_dependency 'pry-rescue', '~> 1.4.4'
-  s.add_dependency 'pry-stack_explorer', '~> 0.4.9.2'
-  s.add_dependency 'pry-byebug', '~> 3.4.2'
   s.add_dependency 'awesome_print', '~> 1.7.0'
 end

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
-unless defined?(Coveralls)
-  require 'simplecov'
-  require 'coveralls'
-  simplecov_settings = nil
-  SimpleCov.formatters = [
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter,
-  ]
-  SimpleCov.start(simplecov_settings) do
-    # This initializer is not executed because no migrations are run.
-    add_filter 'config/initializers/expose_migrations_path.rb'
-    # The version is only used in the gemspec.
-    add_filter 'lib/ontohub_models/version.rb'
-    # Ignore the dummy application that is used for the spec.
-    add_filter 'spec/dummy'
-    # Ignore the RSpec configuration files.
-    add_filter 'spec/spec_helper.rb'
-    add_filter 'spec/rails_helper.rb'
+if RUBY_ENGINE == 'ruby' # not 'rbx'
+  unless defined?(Coveralls)
+    require 'simplecov'
+    require 'coveralls'
+    SimpleCov.formatters = [
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter,
+    ]
+    SimpleCov.start do
+      # This initializer is not executed because no migrations are run.
+      add_filter 'config/initializers/expose_migrations_path.rb'
+      # The version is only used in the gemspec.
+      add_filter 'lib/ontohub_models/version.rb'
+      # Ignore the dummy application that is used for the spec.
+      add_filter 'spec/dummy'
+      # Ignore the RSpec configuration files.
+      add_filter 'spec/spec_helper.rb'
+      add_filter 'spec/rails_helper.rb'
+    end
   end
 end


### PR DESCRIPTION
This adds support for the Ruby interpreter [Rubinius](https://rubinius.com/) ("rbx"). Several development-related gems are not compatible to it:
* pry-byebug
* pry-stack_explorer
* pry-rescue
* simplecov - See https://github.com/rubinius/rubinius/issues/3719

The pry-gems are not important because rbx ships with equivalent tools already. A breakpoint can be set with `Rubinius::Debugger.start`. When a breakpoint is reached, you can list the available debugging commands with `help` or `h`. Navigation through the code (and through the stack frames) is possible.

Incompatibility with SimpleCov is pretty bad, though, because we need a code coverage report during development. However, we can test with both mri and rbx on travis and develop with mri. The coverage report in the pull requests should already be generated with mri-using test run.

---

If you want to try it on your own machine, don't install bundler manually. rbx ships with (an older version of) bundler that should be used instead. Otherwise you will get segfaults with bundler.