### PR TITLE
Add email_hash field to user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,4 +114,8 @@ class User < OrganizationalUnit
     define_method(method) {}
     define_method("#{method}=") { |_ip| }
   end
+
+  def email_hash
+    @email_hash ||= Digest::MD5.hexdigest(email)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe User, type: :model do
     end
   end
 
+  context 'email hash' do
+    subject { build :user, email: 'foobar@example.com' }
+
+    it 'generates the md5 hash of the email address' do
+      expect(subject.email_hash).to eq('0d4907cea9d97688aa7a5e722d742f71')
+    end
+  end
+
   context 'confirmation' do
     subject { create :user }
 


### PR DESCRIPTION
Needed for gravatars, so we don't have to send user's email addresses.