### PR TITLE
Add public key model

### DIFF
--- a/app/models/public_key.rb
+++ b/app/models/public_key.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Class to hold a user's public key
+class PublicKey < Sequel::Model
+  many_to_one :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,13 +15,17 @@ class User < OrganizationalUnit
   devise :database_authenticatable, :registerable, :confirmable, :recoverable,
     :lockable, :trackable
 
+  one_to_many :public_keys
+
   many_to_many :organizations,
     join_table: :organization_memberships, left_key: :member_id
   one_to_many :organization_memberships
   one_to_many :repository_memberships, key: :member_id
 
   plugin :association_dependencies,
-    organizations: :nullify, repository_memberships: :delete
+    organizations: :nullify,
+    repository_memberships: :delete,
+    public_keys: :delete
 
   # equivalent to
   # organizations.reduce([]) do |org_repos, organization|

--- a/db/migrate/20160902111740_initial_schema.rb
+++ b/db/migrate/20160902111740_initial_schema.rb
@@ -127,5 +127,13 @@ Sequel.migration do
       column :path, String, null: false
       index [:repository_id, :commit_sha, :path], unique: true
     end
+
+    create_table :public_keys do
+      primary_key :id
+      foreign_key :user_id, :users, index: true, null: false
+
+      column :name, String, null: false
+      column :key, String, null: false
+    end
   end
 end

--- a/spec/factories/public_keys_factory.rb
+++ b/spec/factories/public_keys_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :public_key do
+    association :user, factory: :user
+    name { Faker::Cat.name }
+    key { Faker::Crypto.sha256 }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -194,6 +194,8 @@ RSpec.describe User, type: :model do
 
   context 'associations' do
     subject { create :user }
+    let!(:public_key1) { create :public_key, user: subject }
+    let!(:public_key2) { create :public_key, user: subject }
     let!(:organization1) { create :organization }
     let!(:organization2) { create :organization }
     let!(:user2) { create :user }
@@ -218,6 +220,18 @@ RSpec.describe User, type: :model do
         id = subject.id
         expect { subject.destroy }.
           to change { Repository.where(owner_id: id).count }.to(0)
+      end
+    end
+
+    context 'public_keys' do
+      it 'returns correct public keys' do
+        expect(subject.public_keys).to match_array([public_key1, public_key2])
+      end
+
+      it 'deletes the public keys on destroy' do
+        id = subject.id
+        expect { subject.destroy }.
+          to change { PublicKey.where(user_id: id).count }.to(0)
       end
     end
 


### PR DESCRIPTION
Closes #88.

To write the public keys to the `authorized_keys` file, we can use [this gem](https://github.com/bjeanes/authorized_keys) (last updated 2013, but it's really small, so it seems to be just done™); IMHO we should do that in the backend explicitly instead of in a create/destroy callback like in the old Ontohub.