### PR TITLE
Provide method to find a users organizations by role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,11 +17,20 @@ class User < OrganizationalUnit
 
   many_to_many :organizations,
     join_table: :organization_memberships, left_key: :member_id
-  one_to_many :organization_memberships
+  one_to_many :organization_memberships, key: :member_id
   one_to_many :repository_memberships, key: :member_id
 
   plugin :association_dependencies,
     organizations: :nullify, repository_memberships: :delete
+
+  # equivalent to
+  # organization_memberships.where(role: role).map(&:organization)
+  def organizations_by_role(role)
+    @organizations_by_role_dataset ||= Organization.dataset.
+      join(:organization_memberships, {organization_id: :id}, select: false).
+      where(Sequel[:organization_memberships][:role] => role,
+            Sequel[:organization_memberships][:member_id] => id)
+  end
 
   # equivalent to
   # organizations.reduce([]) do |org_repos, organization|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -327,4 +327,96 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  context 'organizations_by_role' do
+    subject { create :user }
+    let!(:organization) { create :organization }
+    let!(:membership) do
+      create :organization_membership, member: subject,
+                                       organization: organization,
+                                       role: role
+    end
+
+    context 'with role: admin' do
+      let(:role) { 'admin' }
+
+      context 'query by role: admin' do
+        it 'returns the organization' do
+          expect(subject.organizations_by_role('admin').to_a).
+            to include(organization)
+        end
+      end
+
+      context 'query by invalid role' do
+        it 'raises a database error' do
+          expect { subject.organizations_by_role('invalid').to_a }.
+            to raise_error(Sequel::DatabaseError)
+        end
+      end
+
+      context 'query by role: read' do
+        it 'does not return the organization' do
+          expect(subject.organizations_by_role('read').to_a).
+            not_to include(organization)
+        end
+      end
+
+      context 'query by role: write' do
+        it 'does not return the organization' do
+          expect(subject.organizations_by_role('write').to_a).
+            not_to include(organization)
+        end
+      end
+    end
+
+    context 'with role: read' do
+      let(:role) { 'read' }
+
+      context 'query by role: admin' do
+        it 'does not return the organization' do
+          expect(subject.organizations_by_role('admin').to_a).
+            not_to include(organization)
+        end
+      end
+
+      context 'query by role: read' do
+        it 'returns the organization' do
+          expect(subject.organizations_by_role('read').to_a).
+            to include(organization)
+        end
+      end
+
+      context 'query by role: write' do
+        it 'does not return the organization' do
+          expect(subject.organizations_by_role('write').to_a).
+            not_to include(organization)
+        end
+      end
+    end
+
+    context 'with role: write' do
+      let(:role) { 'write' }
+
+      context 'query by role: admin' do
+        it 'does not return the organization' do
+          expect(subject.organizations_by_role('admin').to_a).
+            not_to include(organization)
+        end
+      end
+
+      context 'query by role: read' do
+        it 'does not return the organization' do
+          expect(subject.organizations_by_role('read').to_a).
+            not_to include(organization)
+        end
+      end
+
+      context 'query by role: write' do
+        it 'returns the organization' do
+          expect(subject.organizations_by_role('write').to_a).
+            to include(organization)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is part of ontohub/ontohub-backend#169. It provides a method with which we can find the user's organizations filtered by role.

I wanted to write it as an association, but I didn't know if it's possible to pass arguments (the role) to an association.