### PR TITLE
Send user mails asynchronously

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,12 @@ PATH
   specs:
     ontohub-models (0.1.0)
       awesome_print (~> 1.8.0)
-      chewy (~> 0.9.0)
+      chewy (~> 0.10.1)
       devise (~> 4.3.0)
       orm_adapter-sequel (~> 0.1.0)
       pry (~> 0.10.4)
       rails (~> 5.1.3)
-      sequel (~> 4.48.0)
+      sequel (~> 4.49.0)
       sequel-devise (~> 0.0.11)
       sequel-rails (~> 0.9.14)
       sequel_pg (~> 1.7.0)
@@ -61,9 +61,10 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (9.0.6)
-    chewy (0.9.0)
-      activesupport (>= 3.2)
-      elasticsearch (>= 1.0.0)
+    chewy (0.10.1)
+      activesupport (>= 4.0)
+      elasticsearch (>= 2.0.0)
+      elasticsearch-dsl
     codecov (0.1.10)
       json
       simplecov
@@ -85,6 +86,7 @@ GEM
       elasticsearch-transport (= 5.0.4)
     elasticsearch-api (5.0.4)
       multi_json
+    elasticsearch-dsl (0.1.5)
     elasticsearch-transport (5.0.4)
       faraday
       multi_json
@@ -128,8 +130,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.4.2)
-      byebug (~> 9.0)
+    pry-byebug (3.4.3)
+      byebug (>= 9.0, < 9.1)
       pry (~> 0.10)
     pry-rescue (1.4.5)
       interception (>= 0.5)
@@ -179,7 +181,7 @@ GEM
     rspec-mocks (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
-    rspec-rails (3.6.0)
+    rspec-rails (3.6.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -188,7 +190,7 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    sequel (4.48.0)
+    sequel (4.49.0)
     sequel-devise (0.0.11)
       devise
       orm_adapter-sequel
@@ -202,11 +204,11 @@ GEM
       sequel (>= 4.0.0)
     sequel_postgresql_triggers (1.3.0)
       sequel
-    simplecov (0.14.1)
+    simplecov (0.15.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.1)
+    simplecov-html (0.10.2)
     slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -215,7 +217,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (0.19.4)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,10 @@ class User < OrganizationalUnit
   devise :database_authenticatable, :registerable, :confirmable, :recoverable,
     :lockable, :trackable
 
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, to_json, *args).deliver_later
+  end
+
   one_to_many :public_keys
 
   many_to_many :organizations,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < OrganizationalUnit
     :lockable, :trackable
 
   def send_devise_notification(notification, *args)
-    devise_mailer.send(notification, to_json, *args).deliver_later
+    devise_mailer.send(notification, id, *args).deliver_later
   end
 
   one_to_many :public_keys

--- a/ontohub-models.gemspec
+++ b/ontohub-models.gemspec
@@ -28,11 +28,11 @@ Gem::Specification.new do |s|
 
   # Runtime dependencies
   s.add_dependency 'rails', '~> 5.1.3'
-  s.add_dependency 'sequel', '~> 4.48.0'
+  s.add_dependency 'sequel', '~> 4.49.0'
   s.add_dependency 'sequel_pg', '~> 1.7.0'
   s.add_dependency 'sequel_postgresql_triggers', '~> 1.3.0'
   s.add_dependency 'sequel-rails', '~> 0.9.14'
-  s.add_dependency 'chewy', '~> 0.9.0'
+  s.add_dependency 'chewy', '~> 0.10.1'
   s.add_dependency 'devise', '~> 4.3.0'
   s.add_dependency 'sequel-devise', '~> 0.0.11'
   s.add_dependency 'orm_adapter-sequel', '~> 0.1.0'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ostruct'
+
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
@@ -8,6 +10,21 @@ RSpec.describe User, type: :model do
     it 'find_for_database_authentication' do
       expect(User.find_for_database_authentication(name: subject.to_param)).
         to eq(subject)
+    end
+  end
+
+  context 'mailer' do
+    before do
+      stub_const('Devise::Mailer', double('Devise::Mailer'))
+      allow(Devise::Mailer).
+        to receive(:test_message).
+        and_return(OpenStruct.new(deliver_later: :ok))
+    end
+
+    subject { create :user }
+
+    it 'calls the mailer asynchronously' do
+      expect(subject.send_devise_notification(:test_message)).to eq(:ok)
     end
   end
 


### PR DESCRIPTION
We need to override the `send_devise_notification` method so that devise uses active job to send the mails asynchronously.