### PR TITLE
Remove timestamps plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,12 +8,6 @@ inherit_from:
 
 # Common configuration.
 AllCops:
-  # What MRI version of the Ruby interpreter is the inspected code intended to
-  # run on? (If there is more than one, set this to the lowest version.)
-  # If a value is specified for TargetRubyVersion then it is used.
-  # Else if .ruby-version exists and it contains an MRI version it is used.
-  # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
-  TargetRubyVersion: 2.3
   # Include common Ruby source files.
   Include:
     - '**/*.gemspec'
@@ -91,12 +85,6 @@ AllCops:
   # cache location is secure from this kind of attack, and wish to use a
   # symlinked cache location, set this value to "true".
   AllowSymlinksInCacheRootDirectory: false
-  # What MRI version of the Ruby interpreter is the inspected code intended to
-  # run on? (If there is more than one, set this to the lowest version.)
-  # If a value is specified for TargetRubyVersion then it is used.
-  # Else if .ruby-version exists and it contains an MRI version it is used.
-  # Otherwise we fallback to the oldest officially supported Ruby version (2.1).
-  TargetRubyVersion: ~
 
 # Indent private/protected/public as deep as method definitions
 Layout/AccessModifierIndentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,12 @@ inherit_from:
 
 # Common configuration.
 AllCops:
+  # What MRI version of the Ruby interpreter is the inspected code intended to
+  # run on? (If there is more than one, set this to the lowest version.)
+  # If a value is specified for TargetRubyVersion then it is used.
+  # Else if .ruby-version exists and it contains an MRI version it is used.
+  # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
+  TargetRubyVersion: 2.4
   # Include common Ruby source files.
   Include:
     - '**/*.gemspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
       sequel-devise (~> 0.0.11)
       sequel-rails (~> 0.9.14)
       sequel_pg (~> 1.7.0)
+      sequel_postgresql_triggers (~> 1.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -95,7 +96,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.8.4)
       i18n (~> 0.5)
-    faraday (0.12.2)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -199,6 +200,8 @@ GEM
     sequel_pg (1.7.0)
       pg (>= 0.8.0)
       sequel (>= 4.0.0)
+    sequel_postgresql_triggers (1.3.0)
+      sequel
     simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)

--- a/app/models/file_version.rb
+++ b/app/models/file_version.rb
@@ -4,7 +4,6 @@
 class FileVersion < LocIdBase
   include ModelWithURL
 
-  plugin :timestamps
   plugin :validation_helpers
 
   many_to_one :repository

--- a/app/models/loc_id_base.rb
+++ b/app/models/loc_id_base.rb
@@ -2,7 +2,6 @@
 
 # Superclass of FileVersion
 class LocIdBase < Sequel::Model
-  plugin :timestamps
   plugin :validation_helpers
   plugin :class_table_inheritance, key: :kind, alias: :loc_id_bases
 

--- a/app/models/organizational_unit.rb
+++ b/app/models/organizational_unit.rb
@@ -2,7 +2,6 @@
 
 # Superclass of Organization and User
 class OrganizationalUnit < Sequel::Model
-  plugin :timestamps
   plugin :validation_helpers
   plugin :class_table_inheritance, key: :kind, alias: :organizational_units
 

--- a/app/models/public_key.rb
+++ b/app/models/public_key.rb
@@ -2,6 +2,5 @@
 
 # Class to hold a user's public key
 class PublicKey < Sequel::Model
-  plugin :timestamps
   many_to_one :user
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -2,7 +2,6 @@
 
 # The Repository model groups libraries and exposes the basic git functinoality.
 class Repository < Sequel::Model
-  plugin :timestamps
   plugin :validation_helpers
 
   include ModelWithURL
@@ -31,7 +30,8 @@ class Repository < Sequel::Model
   end
 
   def add_member(member, role = 'read')
-    repository_membership = RepositoryMembership.find(member: member, repository: self)
+    repository_membership = RepositoryMembership.find(member: member,
+                                                      repository: self)
     if repository_membership
       repository_membership.role = role
       repository_membership.save

--- a/config/initializers/sequel_active_model_serializer.rb
+++ b/config/initializers/sequel_active_model_serializer.rb
@@ -30,7 +30,7 @@ module Sequel
 
         def cache_key
           "#{self.class.to_s.downcase.pluralize}/"\
-            "#{id}-#{updated_at.strftime('%Y%m%d%H%M%S%6N')}"
+            "#{id}-#{updated_at&.strftime('%Y%m%d%H%M%S%6N')}"
         end
       end
     end

--- a/db/migrate/20160902111740_initial_schema.rb
+++ b/db/migrate/20160902111740_initial_schema.rb
@@ -15,10 +15,8 @@ Sequel.migration do
 
       column :display_name, String, null: true
 
-      column :created_at, DateTime, null: false,
-                                    default: Sequel::CURRENT_TIMESTAMP
-      column :updated_at, DateTime, null: false,
-                                    default: Sequel::CURRENT_TIMESTAMP
+      column :created_at, DateTime, null: false # This is set by a trigger
+      column :updated_at, DateTime, null: false # This is set by a trigger
     end
 
     # User is an OrganizationalUnit
@@ -70,10 +68,8 @@ Sequel.migration do
       column :name, String, null: false
       column :key, String, null: false
 
-      column :created_at, DateTime, null: false,
-                                    default: Sequel::CURRENT_TIMESTAMP
-      column :updated_at, DateTime, null: false,
-                                    default: Sequel::CURRENT_TIMESTAMP
+      column :created_at, DateTime, null: false # This is set by a trigger
+      column :updated_at, DateTime, null: false # This is set by a trigger
     end
 
     # Organization is a OrganizationalUnit
@@ -108,10 +104,8 @@ Sequel.migration do
       column :public_access, TrueClass, null: false
       column :content_type, :repository_content_type, null: false
 
-      column :created_at, DateTime, null: false,
-                                    default: Sequel::CURRENT_TIMESTAMP
-      column :updated_at, DateTime, null: false,
-                                    default: Sequel::CURRENT_TIMESTAMP
+      column :created_at, DateTime, null: false # This is set by a trigger
+      column :updated_at, DateTime, null: false # This is set by a trigger
     end
 
     create_enum :repository_role,
@@ -135,10 +129,8 @@ Sequel.migration do
       # The actual Loc/Id is saved in url_path to stay consistent throughout the
       # code.
       column :url_path, String, null: false, unique: true
-      column :created_at, DateTime, null: false,
-                                    default: Sequel::CURRENT_TIMESTAMP
-      column :updated_at, DateTime, null: false,
-                                    default: Sequel::CURRENT_TIMESTAMP
+      column :created_at, DateTime, null: false # This is set by a trigger
+      column :updated_at, DateTime, null: false # This is set by a trigger
     end
 
     # FileVersion is a LocIdBase

--- a/db/migrate/20160902111740_initial_schema.rb
+++ b/db/migrate/20160902111740_initial_schema.rb
@@ -17,7 +17,8 @@ Sequel.migration do
 
       column :created_at, DateTime, null: false,
                                     default: Sequel::CURRENT_TIMESTAMP
-      column :updated_at, DateTime, null: true
+      column :updated_at, DateTime, null: false,
+                                    default: Sequel::CURRENT_TIMESTAMP
     end
 
     # User is an OrganizationalUnit
@@ -71,7 +72,8 @@ Sequel.migration do
 
       column :created_at, DateTime, null: false,
                                     default: Sequel::CURRENT_TIMESTAMP
-      column :updated_at, DateTime, null: true
+      column :updated_at, DateTime, null: false,
+                                    default: Sequel::CURRENT_TIMESTAMP
     end
 
     # Organization is a OrganizationalUnit
@@ -108,7 +110,8 @@ Sequel.migration do
 
       column :created_at, DateTime, null: false,
                                     default: Sequel::CURRENT_TIMESTAMP
-      column :updated_at, DateTime, null: true
+      column :updated_at, DateTime, null: false,
+                                    default: Sequel::CURRENT_TIMESTAMP
     end
 
     create_enum :repository_role,
@@ -134,7 +137,8 @@ Sequel.migration do
       column :url_path, String, null: false, unique: true
       column :created_at, DateTime, null: false,
                                     default: Sequel::CURRENT_TIMESTAMP
-      column :updated_at, DateTime, null: true
+      column :updated_at, DateTime, null: false,
+                                    default: Sequel::CURRENT_TIMESTAMP
     end
 
     # FileVersion is a LocIdBase

--- a/ontohub-models.gemspec
+++ b/ontohub-models.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 5.1.3'
   s.add_dependency 'sequel', '~> 4.48.0'
   s.add_dependency 'sequel_pg', '~> 1.7.0'
+  s.add_dependency 'sequel_postgresql_triggers', '~> 1.3.0'
   s.add_dependency 'sequel-rails', '~> 0.9.14'
   s.add_dependency 'chewy', '~> 0.9.0'
   s.add_dependency 'devise', '~> 4.3.0'

--- a/spec/factories/file_versions_factory.rb
+++ b/spec/factories/file_versions_factory.rb
@@ -9,8 +9,6 @@ FactoryGirl.define do
     association :repository
     commit_sha { Faker::Crypto.sha1 }
     path { generate(:filepath) }
-    created_at { Time.current }
-    updated_at { Time.current }
     url_path_method do
       ->(file_version) { "/file_version/#{file_version.path}" }
     end

--- a/spec/factories/loc_id_bases_factory.rb
+++ b/spec/factories/loc_id_bases_factory.rb
@@ -2,8 +2,6 @@
 
 FactoryGirl.define do
   factory :loc_id_base do
-    created_at { Time.current }
-    updated_at { Time.current }
     url_path_method do
       ->(file_version) { "/loc_id_base/#{file_version.to_param}" }
     end

--- a/spec/factories/organizations_factory.rb
+++ b/spec/factories/organizations_factory.rb
@@ -6,7 +6,5 @@ FactoryGirl.define do
     display_name { Faker::Name.name }
     description { Faker::Company.catch_phrase }
     url_path_method { ->(org) { "/organizations/#{org.to_param}}" } }
-    created_at { Time.current }
-    updated_at { Time.current }
   end
 end

--- a/spec/factories/public_keys_factory.rb
+++ b/spec/factories/public_keys_factory.rb
@@ -5,7 +5,5 @@ FactoryGirl.define do
     association :user, factory: :user
     name { Faker::Cat.name }
     key { Faker::Crypto.sha256 }
-    created_at { Time.current }
-    updated_at { Time.current }
   end
 end

--- a/spec/factories/repositories_factory.rb
+++ b/spec/factories/repositories_factory.rb
@@ -6,8 +6,6 @@ FactoryGirl.define do
     name { generate :repository_name }
     url_path_method { ->(repo) { "/repositories/#{repo.to_param}" } }
     description { Faker::Lorem.sentence }
-    created_at { Time.current }
-    updated_at { Time.current }
     public_access { false }
     content_type { %w(ontology specification model mathematical).sample }
   end

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -4,8 +4,6 @@ FactoryGirl.define do
   factory :user do
     name { generate(:username) } # name is only used for registration
     url_path_method { ->(user) { "/users/#{user.to_param}}" } }
-    created_at { Time.current }
-    updated_at { Time.current }
     display_name { Faker::Name.name }
     email { Faker::Internet.email(name) }
     password { Faker::Internet.password(10) }

--- a/spec/models/file_version_spec.rb
+++ b/spec/models/file_version_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'shared_examples/active_model'
-require 'shared_examples/active_model_serializer'
-require 'shared_examples/model_with_url'
 
 RSpec.describe FileVersion, type: :model do
   context 'validations' do

--- a/spec/models/file_version_spec.rb
+++ b/spec/models/file_version_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe FileVersion, type: :model do
     it_behaves_like 'an ActiveModelSerializer compatible object'
   end
 
+  context 'timestamps' do
+    subject { build(:file_version) }
+    it_behaves_like 'an object with timestamps'
+  end
+
   context 'file version' do
     subject { build :file_version }
 

--- a/spec/models/loc_id_base_spec.rb
+++ b/spec/models/loc_id_base_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'shared_examples/model_with_url'
 
 RSpec.describe LocIdBase, type: :model do
   context 'url' do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -2,11 +2,6 @@
 
 require 'rails_helper'
 
-require 'shared_examples/active_model'
-require 'shared_examples/active_model_serializer'
-require 'shared_examples/model_with_url'
-require 'shared_examples/slug'
-
 RSpec.describe Organization, type: :model do
   context 'compatibility' do
     subject { build :organization }

--- a/spec/models/organizational_unit_spec.rb
+++ b/spec/models/organizational_unit_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'shared_examples/model_with_url'
-require 'shared_examples/slug'
 
 RSpec.shared_examples 'an organizational unit' do
   context 'validations' do

--- a/spec/models/organizational_unit_spec.rb
+++ b/spec/models/organizational_unit_spec.rb
@@ -110,6 +110,11 @@ RSpec.shared_examples 'an organizational unit' do
       let(:other_subject) { create(factory, name: subject.name) }
     end
   end
+
+  context 'timestamps' do
+    subject { build factory }
+    it_behaves_like 'an object with timestamps'
+  end
 end
 
 RSpec.describe OrganizationalUnit, type: :model do

--- a/spec/models/public_key_spec.rb
+++ b/spec/models/public_key_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicKey, type: :model do
+  context 'timestamps' do
+    subject { build(:public_key) }
+    it_behaves_like 'an object with timestamps'
+  end
+end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'shared_examples/active_model'
-require 'shared_examples/active_model_serializer'
-require 'shared_examples/model_with_url'
-require 'shared_examples/slug'
 
 RSpec.describe Repository, type: :model do
   context 'validations' do

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe Repository, type: :model do
     end
   end
 
+  context 'timestamps' do
+    subject { build(:repository) }
+    it_behaves_like 'an object with timestamps'
+  end
+
   context 'file_versions' do
     subject { create(:repository, name: Faker::Lorem.words(2).join(' ')) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,11 +2,6 @@
 
 require 'rails_helper'
 
-require 'shared_examples/active_model'
-require 'shared_examples/active_model_serializer'
-require 'shared_examples/model_with_url'
-require 'shared_examples/slug'
-
 RSpec.describe User, type: :model do
   context 'warden' do
     subject { create :user }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'support/simplecov'
-
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../spec/dummy/config/environment', __FILE__)
@@ -9,25 +7,9 @@ require File.expand_path('../../spec/dummy/config/environment', __FILE__)
 if Rails.env.production?
   abort('The Rails environment is running in production mode!')
 end
-require 'factory_girl_rails'
 require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/shared_examples/active_model_serializer.rb
+++ b/spec/shared_examples/active_model_serializer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'shared_examples/active_model_serializer_with_devise'
-
 # This is the RSpec formulation of ActiveModel::Serializer::Lint::Tests
 RSpec.shared_examples 'an ActiveModelSerializer compatible object' do
   it_behaves_like 'an ActiveModelSerializer compatible object with devise'

--- a/spec/shared_examples/an_object_with_timestamps.rb
+++ b/spec/shared_examples/an_object_with_timestamps.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an object with timestamps' do
+  context 'without transactions', no_transaction: true do
+    let!(:before_time) { Time.now }
+
+    before do
+      # Don't send emails
+      allow_any_instance_of(User).to receive(:send_devise_notification)
+      subject.save
+      subject.reload
+    end
+
+    it 'sets the created_at timestamp on save' do
+      expect(subject.created_at).to be > before_time
+    end
+
+    it 'has an updated_at value equal to the created_at value' do
+      expect(subject.updated_at).to eq(subject.created_at)
+    end
+
+    it 'sets the updated_at value on update' do
+      subject.save
+      subject.reload
+      expect(subject.updated_at).to be > subject.created_at
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'support/simplecov'
+require_relative 'support/cleaning_helpers'
 
 require 'rspec'
 require 'database_cleaner'
@@ -59,19 +60,6 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = :random
-
-  # DatabaseCleaner should perform after every example and a full clean before
-  # the suite
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
-  end
 
   # Allow to find all factories
   config.include FactoryGirl::Syntax::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-require_relative 'support/simplecov'
-require_relative 'support/cleaning_helpers'
+Dir.glob('spec/support/**/*.rb').each do |file|
+  require_relative file.sub(%r{\Aspec/}, '')
+end
+Dir.glob('spec/shared_examples/**/*.rb').each do |file|
+  require_relative file.sub(%r{\Aspec/}, '')
+end
 
 require 'rspec'
 require 'database_cleaner'

--- a/spec/support/cleaning_helpers.rb
+++ b/spec/support/cleaning_helpers.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  # DatabaseCleaner should perform after every example and a full clean before
+  # the suite
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each, :no_transaction) do |example|
+    DatabaseCleaner.strategy = :truncation
+    example.run
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
This removes the sequel timestamps plugin ins favour of database-level triggers. The functionality is basically the same, but this way, we can skip the timestamp-handling in Hets because the database already takes care of it.

Notes
--

**Transactions** need to be disabled because the timestamps will all be equal otherwise.

**Mailing** needs to be stubbed away because a mail is sent as soon as a user-creating transation is committed.

**Line coverage percentage** decreased because there are fewer lines.