### PR TITLE
Bundle update.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       url
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    crass (1.0.2)
     database_cleaner (1.6.1)
     debug_inspector (0.0.3)
     devise (4.3.0)
@@ -105,7 +106,8 @@ GEM
     i18n (0.8.6)
     interception (0.5)
     json (2.1.0)
-    loofah (2.0.3)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
@@ -113,13 +115,13 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     multi_json (1.12.2)
     multipart-post (2.0.0)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     orm_adapter-sequel (0.1.0)
       activemodel (>= 3.0.0)
@@ -203,7 +205,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.8.3)
     sequel (4.49.0)
     sequel-devise (0.0.11)
       devise
@@ -218,7 +220,7 @@ GEM
       sequel (>= 4.0.0)
     sequel_postgresql_triggers (1.3.0)
       sequel
-    simplecov (0.15.0)
+    simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -262,4 +264,4 @@ DEPENDENCIES
   rubocop (~> 0.49.1)
 
 BUNDLED WITH
-   1.14.6
+   1.15.4


### PR DESCRIPTION
This updates the second-tier dependencies, especially nokogiri with its [USN-3424-1](https://usn.ubuntu.com/usn/usn-3424-1/) security issue.