### PR TITLE
Improve travis build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 dist: trusty
 
 language: ruby
+cache: bundler
 
 rvm:
   - 2.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 
 language: ruby


### PR DESCRIPTION
Caches bundler (reduces build time by 50%) and builds on docker (starts in 1s instead of 20s on a VM).