### PR TITLE
Bump FactoryGirl from 4.8.0 to FactoryBot 4.8.2.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,10 +92,10 @@ GEM
       faraday
       multi_json
     erubi (1.6.1)
-    factory_girl (4.8.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faker (1.8.4)
       i18n (~> 0.5)
@@ -250,7 +250,7 @@ DEPENDENCIES
   bundler (~> 1.11)
   codecov (~> 0.1.10)
   database_cleaner (~> 1.6.1)
-  factory_girl_rails (~> 4.8.0)
+  factory_bot_rails (~> 4.8.2)
   faker (~> 1.8.4)
   ontohub-models!
   pry-byebug (~> 3.5.0)

--- a/lib/ontohub-models/engine.rb
+++ b/lib/ontohub-models/engine.rb
@@ -12,8 +12,8 @@ module OntohubModels
 
     config.generators do |g|
       g.test_framework :rspec
-      g.fixture_replacement :factory_girl, dir: 'spec/factories',
-                                           suffix: 'factory'
+      g.fixture_replacement :factory_bot, dir: 'spec/factories',
+                                          suffix: 'factory'
     end
     config.sequel.after_connect = proc do
       begin

--- a/ontohub-models.gemspec
+++ b/ontohub-models.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.6.0'
   s.add_development_dependency 'rspec-rails', '~> 3.6.0'
   s.add_development_dependency 'database_cleaner', '~> 1.6.1'
-  s.add_development_dependency 'factory_girl_rails', '~> 4.8.0'
+  s.add_development_dependency 'factory_bot_rails', '~> 4.8.2'
   s.add_development_dependency 'faker', '~> 1.8.4'
 
   # CI services

--- a/spec/factories/cons_statuses_factory.rb
+++ b/spec/factories/cons_statuses_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :cons_status do
     required do
       %w(inconsistent string none pcons cons mono def).sample

--- a/spec/factories/diagnoses_factory.rb
+++ b/spec/factories/diagnoses_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :diagnosis, class: Debug do
     association :file_version
     association :file_range

--- a/spec/factories/document_links_factory.rb
+++ b/spec/factories/document_links_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :document_link do
     association :source, factory: :document
     association :target, factory: :document

--- a/spec/factories/documents_factory.rb
+++ b/spec/factories/documents_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :document do
     association :file_version
     kind { [Library, NativeDocument].sample.to_s }

--- a/spec/factories/factory_helper.rb
+++ b/spec/factories/factory_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'faker'
-FactoryGirl.define do
+FactoryBot.define do
   to_create(&:save)
 
   sequence(:filepath) do |n|

--- a/spec/factories/file_ranges_factory.rb
+++ b/spec/factories/file_ranges_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :file_range do
     path { generate(:filepath) }
     start_line { rand(10) }

--- a/spec/factories/file_version_parents_factory.rb
+++ b/spec/factories/file_version_parents_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :file_version_parent do
     association :last_changed_file_version, factory: :file_version
     queried_sha { Faker::Crypto.sha1 }

--- a/spec/factories/file_versions_factory.rb
+++ b/spec/factories/file_versions_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :file_version do
     association :repository
     commit_sha { Faker::Crypto.sha1 }

--- a/spec/factories/generated_axioms_factory.rb
+++ b/spec/factories/generated_axioms_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :generated_axiom do
     association :reasoning_attempt
     text { Faker::Lorem.sentence }

--- a/spec/factories/language_mappings_factory.rb
+++ b/spec/factories/language_mappings_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :language_mapping do
     association :source, factory: :language
     association :target, factory: :language

--- a/spec/factories/languages_factory.rb
+++ b/spec/factories/languages_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :language do
     name { Faker::Lorem.words(4, true).join(' ') }
     slug { name.parameterize }

--- a/spec/factories/loc_id_bases_factory.rb
+++ b/spec/factories/loc_id_bases_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :loc_id_base, class: NativeDocument do
     association :file_version
     loc_id { "/#{Faker::Name.unique.title.tr(' ', '/')}" }

--- a/spec/factories/logic_mappings_factory.rb
+++ b/spec/factories/logic_mappings_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :logic_mapping do
     association :language_mapping, factory: :language_mapping
     association :source, factory: :logic

--- a/spec/factories/logics_factory.rb
+++ b/spec/factories/logics_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :logic do
     association :language
     name { Faker::Lorem.words(rand(4) + 1).join(' ') }

--- a/spec/factories/mappings_factory.rb
+++ b/spec/factories/mappings_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :mapping do
     association :source, factory: :oms
     association :target, factory: :oms

--- a/spec/factories/oms_factory.rb
+++ b/spec/factories/oms_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :oms, class: OMS do
     association :document
     association :language

--- a/spec/factories/organization_memberships_factory.rb
+++ b/spec/factories/organization_memberships_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :organization_membership do
     association :organization
     association :member, factory: :user

--- a/spec/factories/organizations_factory.rb
+++ b/spec/factories/organizations_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :organization do
     name { generate(:username) }
     display_name { Faker::Name.name }

--- a/spec/factories/premise_selections_factory.rb
+++ b/spec/factories/premise_selections_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :premise_selection, class: ManualPremiseSelection do
     association :reasoner_configuration
 

--- a/spec/factories/public_keys_factory.rb
+++ b/spec/factories/public_keys_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :public_key do
     association :user, factory: :user
     name { Faker::Cat.unique.name }

--- a/spec/factories/reasoner_configurations_factory.rb
+++ b/spec/factories/reasoner_configurations_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :reasoner_configuration do
     association :configured_reasoner, factory: :reasoner
     time_limit { rand(60) }

--- a/spec/factories/reasoner_outputs_factory.rb
+++ b/spec/factories/reasoner_outputs_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :reasoner_output do
     association :reasoning_attempt
     association :reasoner

--- a/spec/factories/reasoners_factory.rb
+++ b/spec/factories/reasoners_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :reasoner do
     display_name { Faker::Lorem.words(4).join(' ') }
     slug { display_name.parameterize }

--- a/spec/factories/reasoning_attempts_factory.rb
+++ b/spec/factories/reasoning_attempts_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :reasoning_attempt, class: ProofAttempt do
     association :conjecture
     association :reasoner_configuration

--- a/spec/factories/repositories_factory.rb
+++ b/spec/factories/repositories_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :repository do
     association :owner, factory: :user
     name { generate :repository_name }

--- a/spec/factories/repository_memberships_factory.rb
+++ b/spec/factories/repository_memberships_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :repository_membership do
     association :repository
     association :member, factory: :user

--- a/spec/factories/sentences_factory.rb
+++ b/spec/factories/sentences_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :sentence, class: Axiom do
     association :oms
     association :file_range

--- a/spec/factories/serializations_factory.rb
+++ b/spec/factories/serializations_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :serialization do
     association :language
     name { Faker::Lorem.words(4, true).join(' ') }

--- a/spec/factories/signature_morphisms_factory.rb
+++ b/spec/factories/signature_morphisms_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :signature_morphism do
     association :logic_mapping
     association :source, factory: :signature

--- a/spec/factories/signature_symbols_factory.rb
+++ b/spec/factories/signature_symbols_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :signature_symbol do
     association :signature
     association :symbol

--- a/spec/factories/signatures_factory.rb
+++ b/spec/factories/signatures_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :signature do
     association :language
     as_json { '{}' }

--- a/spec/factories/sine_symbol_commonnesses_factory.rb
+++ b/spec/factories/sine_symbol_commonnesses_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :sine_symbol_commonness do
     association :sine_premise_selection
     association :symbol

--- a/spec/factories/sine_symbol_premise_triggers_factory.rb
+++ b/spec/factories/sine_symbol_premise_triggers_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :sine_symbol_premise_trigger do
     association :sine_premise_selection
     association :symbol

--- a/spec/factories/symbol_mappings_factory.rb
+++ b/spec/factories/symbol_mappings_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :symbol_mapping do
     association :signature_morphism
     association :source, factory: :symbol

--- a/spec/factories/symbols_factory.rb
+++ b/spec/factories/symbols_factory.rb
@@ -1,7 +1,7 @@
 
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :symbol, class: OMSSymbol do
     association :oms, factory: :oms
     association :file_range

--- a/spec/factories/url_mappings_factory.rb
+++ b/spec/factories/url_mappings_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :url_mapping do
     association :repository
     source { Faker::Lorem.word }

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     name { generate(:username) } # name is only used for registration
     display_name { Faker::Name.name }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ end
 
 require 'rspec'
 require 'database_cleaner'
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -66,5 +66,5 @@ RSpec.configure do |config|
   config.order = :random
 
   # Allow to find all factories
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
FactoryGirl was [renamed to FactoryBot](https://github.com/iHiD/factory_bot/blob/00a5277cb48feaf4c92653442c646442a117c9bd/NAME.md). This migrates the changes.