### PR TITLE
Fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,37 +4,61 @@
 inherit_from:
   - .rubocop_enabled.yml
   - .rubocop_disabled.yml
+  # This file is ignored by rubocop, but we track the changes we made to the
+  # default config there:
   - .rubocop_modified.yml
 
 # Common configuration.
 AllCops:
-  # What MRI version of the Ruby interpreter is the inspected code intended to
-  # run on? (If there is more than one, set this to the lowest version.)
-  # If a value is specified for TargetRubyVersion then it is used.
-  # Else if .ruby-version exists and it contains an MRI version it is used.
-  # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
-  TargetRubyVersion: 2.4
   # Include common Ruby source files.
   Include:
+    - '**/*.builder'
+    - '**/*.fcgi'
     - '**/*.gemspec'
-    - '**/*.podspec'
+    - '**/*.god'
+    - '**/*.jb'
     - '**/*.jbuilder'
-    - '**/*.rake'
+    - '**/*.mspec'
     - '**/*.opal'
+    - '**/*.pluginspec'
+    - '**/*.podspec'
+    - '**/*.rabl'
+    - '**/*.rake'
+    - '**/*.rbuild'
+    - '**/*.rbw'
+    - '**/*.rbx'
+    - '**/*.ru'
+    - '**/*.ruby'
+    - '**/*.spec'
+    - '**/*.thor'
+    - '**/*.watchr'
+    - '**/.irbrc'
+    - '**/.pryrc'
+    - '**/buildfile'
     - '**/config.ru'
-    - '**/Gemfile'
-    - '**/Rakefile'
-    - '**/Capfile'
-    - '**/Guardfile'
-    - '**/Podfile'
-    - '**/Thorfile'
-    - '**/Vagrantfile'
+    - '**/Appraisals'
     - '**/Berksfile'
+    - '**/Brewfile'
+    - '**/Buildfile'
+    - '**/Capfile'
     - '**/Cheffile'
-    - '**/Vagabondfile'
+    - '**/Dangerfile'
+    - '**/Deliverfile'
     - '**/Fastfile'
     - '**/*Fastfile'
+    - '**/Gemfile'
+    - '**/Guardfile'
+    - '**/Jarfile'
+    - '**/Mavenfile'
+    - '**/Podfile'
+    - '**/Puppetfile'
+    - '**/Rakefile'
+    - '**/Snapfile'
+    - '**/Thorfile'
+    - '**/Vagabondfile'
+    - '**/Vagrantfile'
   Exclude:
+    - 'apidoc/**/*'
     - 'bin/bundle'
     - 'bin/rails'
     - 'bin/rake'
@@ -42,6 +66,7 @@ AllCops:
     - 'bin/spring'
     - 'bin/update'
     - 'db/schema.rb'
+    - 'node_modules/**/*'
     - 'spec/dummy/**/*'
     - 'vendor/**/*'
   # Default formatter will be used if no `-f/--format` option is given.
@@ -66,11 +91,17 @@ AllCops:
   # the `--only-guide-cops` option.
   StyleGuideCopsOnly: false
   # All cops except the ones in disabled.yml are enabled by default. Change
-  # this behavior by overriding `DisabledByDefault`. When `DisabledByDefault` is
-  # `true`, all cops in the default configuration are disabled, and only cops
-  # in user configuration are enabled. This makes cops opt-in instead of
-  # opt-out. Note that when `DisabledByDefault` is `true`, cops in user
-  # configuration will be enabled even if they don't set the Enabled parameter.
+  # this behavior by overriding either `DisabledByDefault` or `EnabledByDefault`.
+  # When `DisabledByDefault` is `true`, all cops in the default configuration
+  # are disabled, and only cops in user configuration are enabled. This makes
+  # cops opt-in instead of opt-out. Note that when `DisabledByDefault` is `true`,
+  # cops in user configuration will be enabled even if they don't set the
+  # Enabled parameter.
+  # When `EnabledByDefault` is `true`, all cops, even those in disabled.yml,
+  # are enabled by default.  Cops can still be disabled in user configuration.
+  # Note that it is invalid to set both EnabledByDefault and DisabledByDefault
+  # to true in the same configuration.
+  EnabledByDefault: false
   DisabledByDefault: false
   # Enables the result cache if `true`. Can be overridden by the `--cache` command
   # line option.
@@ -78,19 +109,27 @@ AllCops:
   # Threshold for how many files can be stored in the result cache before some
   # of the files are automatically removed.
   MaxFilesInCache: 20000
-  # The cache will be stored in "rubocop_cache" under this directory. The name
-  # "/tmp" is special and will be converted to the system temporary directory,
-  # which is "/tmp" on Unix-like systems, but could be something else on other
-  # systems.
+  # The cache will be stored in "rubocop_cache" under this directory. If
+  # CacheRootDirectory is ~ (nil), which it is by default, the root will be
+  # taken from the environment variable `$XDG_CACHE_HOME` if it is set, or if
+  # `$XDG_CACHE_HOME` is not set, it will be `$HOME/.cache/`.
   CacheRootDirectory: /tmp
-  # The default cache root directory is /tmp, which on most systems is
-  # writable by any system user. This means that it is possible for a
-  # malicious user to anticipate the location of Rubocop's cache directory,
-  # and create a symlink in its place that could cause Rubocop to overwrite
-  # unintended files, or read malicious input. If you are certain that your
-  # cache location is secure from this kind of attack, and wish to use a
-  # symlinked cache location, set this value to "true".
-  AllowSymlinksInCacheRootDirectory: false
+  # It is possible for a malicious user to know the location of RuboCop's cache
+  # directory by looking at CacheRootDirectory, and create a symlink in its
+  # place that could cause RuboCop to overwrite unintended files, or read
+  # malicious input. If you are certain that your cache location is secure from
+  # this kind of attack, and wish to use a symlinked cache location, set this
+  # value to "true".
+  AllowSymlinksInCacheRootDirectory: true
+  # What MRI version of the Ruby interpreter is the inspected code intended to
+  # run on? (If there is more than one, set this to the lowest version.)
+  # If a value is specified for TargetRubyVersion then it is used.
+  # Else if .ruby-version exists and it contains an MRI version it is used.
+  # Otherwise we fallback to the oldest officially supported Ruby version (2.1).
+  TargetRubyVersion: 2.4
+  TargetRailsVersion: 5.1
+
+#################### Layout ###########################
 
 # Indent private/protected/public as deep as method definitions
 Layout/AccessModifierIndentation:
@@ -98,15 +137,9 @@ Layout/AccessModifierIndentation:
   SupportedStyles:
     - outdent
     - indent
-  # By default, the indentation width from Style/IndentationWidth is used
+  # By default, the indentation width from Layout/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
-
-Style/Alias:
-  EnforcedStyle: prefer_alias
-  SupportedStyles:
-    - prefer_alias
-    - prefer_alias_method
 
 # Align the elements of a hash literal if they span more than one line.
 Layout/AlignHash:
@@ -198,9 +231,454 @@ Layout/AlignParameters:
   SupportedStyles:
     - with_first_parameter
     - with_fixed_indentation
-  # By default, the indentation width from Style/IndentationWidth is used
+  # By default, the indentation width from Layout/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
+
+# Indentation of `when`.
+Layout/CaseIndentation:
+  EnforcedStyle: case
+  SupportedStyles:
+    - case
+    - end
+  IndentOneStep: false
+  # By default, the indentation width from `Layout/IndentationWidth` is used.
+  # But it can be overridden by setting this parameter.
+  # This only matters if `IndentOneStep` is `true`
+  IndentationWidth: ~
+
+# Multi-line method chaining should be done with leading dots.
+Layout/DotPosition:
+  EnforcedStyle: trailing
+  SupportedStyles:
+    - leading
+    - trailing
+
+# Use empty lines between defs.
+Layout/EmptyLineBetweenDefs:
+  # If `true`, this parameter means that single line method definitions don't
+  # need an empty line between them.
+  AllowAdjacentOneLineDefs: false
+  # Can be array to specify minimum and maximum number of empty lines, e.g. [1, 2]
+  NumberOfEmptyLines: 1
+
+Layout/EmptyLinesAroundBlockBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+Layout/EmptyLinesAroundClassBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - empty_lines_except_namespace
+    - empty_lines_special
+    - no_empty_lines
+
+Layout/EmptyLinesAroundModuleBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - empty_lines_except_namespace
+    - empty_lines_special
+    - no_empty_lines
+
+Layout/EndOfLine:
+  # The `native` style means that CR+LF (Carriage Return + Line Feed) is
+  # enforced on Windows, and LF is enforced on other platforms. The other styles
+  # mean LF and CR+LF, respectively.
+  EnforcedStyle: native
+  SupportedStyles:
+    - native
+    - lf
+    - crlf
+
+Layout/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+  # When true, forces the alignment of `=` in assignments on consecutive lines.
+  ForceEqualSignAlignment: false
+
+Layout/FirstParameterIndentation:
+  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  SupportedStyles:
+    # The first parameter should always be indented one step more than the
+    # preceding line.
+    - consistent
+    # The first parameter should normally be indented one step more than the
+    # preceding line, but if it's a parameter for a method call that is itself
+    # a parameter in a method call, then the inner parameter should be indented
+    # relative to the inner method.
+    - special_for_inner_method_call
+    # Same as `special_for_inner_method_call` except that the special rule only
+    # applies if the outer method call encloses its arguments in parentheses.
+    - special_for_inner_method_call_in_parentheses
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Layout/IndentationConsistency:
+  # The difference between `rails` and `normal` is that the `rails` style
+  # prescribes that in classes and modules the `protected` and `private`
+  # modifier keywords shall be indented the same as public methods and that
+  # protected and private members shall be indented one step more than the
+  # modifiers. Other than that, both styles mean that entities on the same
+  # logical depth shall have the same indentation.
+  EnforcedStyle: normal
+  SupportedStyles:
+    - normal
+    - rails
+
+Layout/IndentationWidth:
+  # Number of spaces for each indentation level.
+  Width: 2
+  IgnoredPatterns: []
+
+# Checks the indentation of the first element in an array literal.
+Layout/IndentArray:
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of assignment RHS, when on a different line from LHS
+Layout/IndentAssignment:
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of the first key in a hash literal.
+Layout/IndentHash:
+  # The value `special_inside_parentheses` means that hash literals with braces
+  # that have their opening brace on the same line as a surrounding opening
+  # round parenthesis, shall have their first key indented relative to the
+  # first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first key shall
+  # always be relative to the first position of the line where the opening
+  # brace is.
+  #
+  # The value `align_braces` means that the indentation of the first key shall
+  # always be relative to the position of the opening brace.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_braces
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Layout/IndentHeredoc:
+  EnforcedStyle: auto_detection
+  SupportedStyles:
+    - auto_detection
+    - squiggly
+    - active_support
+    - powerpack
+    - unindent
+
+Layout/SpaceInLambdaLiteral:
+  EnforcedStyle: require_no_space
+  SupportedStyles:
+    - require_no_space
+    - require_space
+
+Layout/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Layout/MultilineAssignmentLayout:
+  # The types of assignments which are subject to this rule.
+  SupportedTypes:
+    - block
+    - case
+    - class
+    - if
+    - kwbegin
+    - module
+  EnforcedStyle: new_line
+  SupportedStyles:
+    # Ensures that the assignment operator and the rhs are on the same line for
+    # the set of supported types.
+    - same_line
+    # Ensures that the assignment operator and the rhs are on separate lines
+    # for the set of supported types.
+    - new_line
+
+Layout/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Layout/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last argument
+    - symmetrical
+    - new_line
+    - same_line
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  SupportedStyles:
+    - aligned
+    - indented
+    - indented_relative_to_receiver
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last parameter
+    - symmetrical
+    - new_line
+    - same_line
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Layout/SpaceAroundBlockParameters:
+  EnforcedStyleInsidePipes: no_space
+  SupportedStylesInsidePipes:
+    - space
+    - no_space
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+
+Layout/SpaceAroundOperators:
+  # When `true`, allows most uses of extra spacing if the intent is to align
+  # with an operator on the previous or next line, not counting empty lines
+  # or comment lines.
+  AllowForAlignment: true
+
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+  SupportedStylesForEmptyBraces:
+    - space
+    - no_space
+
+Layout/SpaceBeforeFirstArg:
+  # When `true`, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+
+Layout/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStylesForEmptyBraces:
+    - space
+    - no_space
+  # Space between `{` and `|`. Overrides `EnforcedStyle` if there is a conflict.
+  SpaceBeforeBlockParameters: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+  SupportedStyles:
+    - space
+    - no_space
+    # 'compact' normally requires a space inside hash braces, with the exception
+    # that successive left braces or right braces are collapsed together
+    - compact
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStylesForEmptyBraces:
+    - space
+    - no_space
+
+Layout/SpaceInsideStringInterpolation:
+  EnforcedStyle: no_space
+  SupportedStyles:
+    - space
+    - no_space
+
+Layout/Tab:
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  # It is used during auto-correction to determine how many spaces should
+  # replace each tab.
+  IndentationWidth: ~
+
+Layout/TrailingBlankLines:
+  EnforcedStyle: final_newline
+  SupportedStyles:
+    - final_newline
+    - final_blank_line
+
+#################### Naming ##########################
+
+Naming/FileName:
+  # File names listed in `AllCops:Include` are excluded by default. Add extra
+  # excludes here.
+  Exclude: []
+  # When `true`, requires that each source file should define a class or module
+  # with a name which matches the file name (converted to ... case).
+  # It further expects it to be nested inside modules which match the names
+  # of subdirectories in its path.
+  ExpectMatchingDefinition: false
+  # If non-`nil`, expect all source file names to match the following regex.
+  # Only the file name itself is matched, not the entire file path.
+  # Use anchors as necessary if you want to match the entire name rather than
+  # just a part of it.
+  Regex: ~
+  # With `IgnoreExecutableScripts` set to `true`, this cop does not
+  # report offending filenames for executable scripts (i.e. source
+  # files with a shebang in the first line).
+  IgnoreExecutableScripts: true
+  AllowedAcronyms:
+    - CLI
+    - DSL
+    - ACL
+    - API
+    - ASCII
+    - CPU
+    - CSS
+    - DNS
+    - EOF
+    - GUID
+    - HTML
+    - HTTP
+    - HTTPS
+    - ID
+    - IP
+    - JSON
+    - LHS
+    - QPS
+    - RAM
+    - RHS
+    - RPC
+    - SLA
+    - SMTP
+    - SQL
+    - SSH
+    - TCP
+    - TLS
+    - TTL
+    - UDP
+    - UI
+    - UID
+    - UUID
+    - URI
+    - URL
+    - UTF8
+    - VM
+    - XML
+    - XMPP
+    - XSRF
+    - XSS
+
+Naming/HeredocDelimiterNaming:
+  Blacklist:
+    - END
+    - !ruby/regexp '/EO[A-Z]{1}/'
+
+Naming/HeredocDelimiterCase:
+  EnforcedStyle: uppercase
+  SupportedStyles:
+    - lowercase
+    - uppercase
+
+Naming/MethodName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    - snake_case
+    - camelCase
+
+Naming/PredicateName:
+  # Predicate name prefixes.
+  NamePrefix:
+    - is_
+    - has_
+    - have_
+  # Predicate name prefixes that should be removed.
+  NamePrefixBlacklist:
+    - is_
+    - has_
+    - have_
+  # Predicate names which, despite having a blacklisted prefix, or no `?`,
+  # should still be accepted
+  NameWhitelist:
+    - is_a?
+  # Method definition macros for dynamically generated methods.
+  MethodDefinitionMacros:
+    - define_method
+    - define_singleton_method
+  # Exclude Rspec specs because there is a strong convention to write spec
+  # helpers in the form of `have_something` or `be_something`.
+  Exclude:
+    - 'spec/**/*'
+
+Naming/VariableName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    - snake_case
+    - camelCase
+
+Naming/VariableNumber:
+  EnforcedStyle: normalcase
+  SupportedStyles:
+    - snake_case
+    - normalcase
+    - non_integer
+
+#################### Style ###########################
+
+Style/Alias:
+  EnforcedStyle: prefer_alias
+  SupportedStyles:
+    - prefer_alias
+    - prefer_alias_method
 
 Style/AndOr:
   # Whether `and` and `or` are banned only in conditionals (conditionals)
@@ -209,7 +687,6 @@ Style/AndOr:
   SupportedStyles:
     - always
     - conditionals
-
 
 # Checks if usage of `%()` or `%Q()` matches configuration.
 Style/BarePercentLiterals:
@@ -302,18 +779,6 @@ Style/BracesAroundHashParameters:
     # braces around it, but requires braces if the second to last parameter is
     # also a hash literal.
     - context_dependent
-
-# Indentation of `when`.
-Layout/CaseIndentation:
-  EnforcedStyle: case
-  SupportedStyles:
-    - case
-    - end
-  IndentOneStep: false
-  # By default, the indentation width from `Style/IndentationWidth` is used.
-  # But it can be overridden by setting this parameter.
-  # This only matters if `IndentOneStep` is `true`
-  IndentationWidth: ~
 
 Style/ClassAndModuleChildren:
   # Checks the style of children definitions at classes and modules.
@@ -419,13 +884,6 @@ Style/Copyright:
 Style/DocumentationMethod:
   RequireForNonPublicMethods: false
 
-# Multi-line method chaining should be done with leading dots.
-Layout/DotPosition:
-  # EnforcedStyle: leading
-  SupportedStyles:
-    - leading
-    - trailing
-
 # Warn on empty else statements
 # empty - warn only on empty `else`
 # nil - warn on `else` with nil in it
@@ -437,146 +895,11 @@ Style/EmptyElse:
     - nil
     - both
 
-# Use empty lines between defs.
-Layout/EmptyLineBetweenDefs:
-  # If `true`, this parameter means that single line method definitions don't
-  # need an empty line between them.
-  AllowAdjacentOneLineDefs: false
-
-Layout/EmptyLinesAroundBlockBody:
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-    - empty_lines
-    - no_empty_lines
-
-Layout/EmptyLinesAroundClassBody:
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-    - empty_lines
-    - empty_lines_except_namespace
-    - empty_lines_special
-    - no_empty_lines
-
-Layout/EmptyLinesAroundModuleBody:
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-    - empty_lines
-    - empty_lines_except_namespace
-    - empty_lines_special
-    - no_empty_lines
-
 Style/EmptyMethod:
   EnforcedStyle: compact
   SupportedStyles:
     - compact
     - expanded
-
-# Checks whether the source file has a utf-8 encoding comment or not
-# AutoCorrectEncodingComment must match the regex
-# /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
-Style/Encoding:
-  EnforcedStyle: never
-  SupportedStyles:
-    - when_needed
-    - always
-    - never
-  AutoCorrectEncodingComment: '# encoding: utf-8'
-
-Layout/EndOfLine:
-  # The `native` style means that CR+LF (Carriage Return + Line Feed) is
-  # enforced on Windows, and LF is enforced on other platforms. The other styles
-  # mean LF and CR+LF, respectively.
-  EnforcedStyle: native
-  SupportedStyles:
-    - native
-    - lf
-    - crlf
-
-Layout/ExtraSpacing:
-  # When true, allows most uses of extra spacing if the intent is to align
-  # things with the previous or next line, not counting empty lines or comment
-  # lines.
-  AllowForAlignment: true
-  # When true, forces the alignment of `=` in assignments on consecutive lines.
-  ForceEqualSignAlignment: false
-
-Naming/FileName:
-  # File names listed in `AllCops:Include` are excluded by default. Add extra
-  # excludes here.
-  Exclude: []
-  # When `true`, requires that each source file should define a class or module
-  # with a name which matches the file name (converted to ... case).
-  # It further expects it to be nested inside modules which match the names
-  # of subdirectories in its path.
-  ExpectMatchingDefinition: false
-  # If non-`nil`, expect all source file names to match the following regex.
-  # Only the file name itself is matched, not the entire file path.
-  # Use anchors as necessary if you want to match the entire name rather than
-  # just a part of it.
-  Regex: ~
-  # With `IgnoreExecutableScripts` set to `true`, this cop does not
-  # report offending filenames for executable scripts (i.e. source
-  # files with a shebang in the first line).
-  IgnoreExecutableScripts: true
-  AllowedAcronyms:
-    - CLI
-    - DSL
-    - ACL
-    - API
-    - ASCII
-    - CPU
-    - CSS
-    - DNS
-    - EOF
-    - GUID
-    - HTML
-    - HTTP
-    - HTTPS
-    - ID
-    - IP
-    - JSON
-    - LHS
-    - QPS
-    - RAM
-    - RHS
-    - RPC
-    - SLA
-    - SMTP
-    - SQL
-    - SSH
-    - TCP
-    - TLS
-    - TTL
-    - UDP
-    - UI
-    - UID
-    - UUID
-    - URI
-    - URL
-    - UTF8
-    - VM
-    - XML
-    - XMPP
-    - XSRF
-    - XSS
-
-Layout/FirstParameterIndentation:
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
-  SupportedStyles:
-    # The first parameter should always be indented one step more than the
-    # preceding line.
-    - consistent
-    # The first parameter should normally be indented one step more than the
-    # preceding line, but if it's a parameter for a method call that is itself
-    # a parameter in a method call, then the inner parameter should be indented
-    # relative to the inner method.
-    - special_for_inner_method_call
-    # Same as `special_for_inner_method_call` except that the special rule only
-    # applies if the outer method call encloses its arguments in parentheses.
-    - special_for_inner_method_call_in_parentheses
-  # By default, the indentation width from `Style/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
 
 # Checks use of for or each in multiline loops.
 Style/For:
@@ -592,6 +915,16 @@ Style/FormatString:
     - format
     - sprintf
     - percent
+
+# Enforce using either `%<token>s` or `%{token}`
+Style/FormatStringToken:
+  EnforcedStyle: annotated
+  SupportedStyles:
+    # Prefer tokens which contain a sprintf like type annotation like
+    # `%<name>s`, `%<age>d`, `%<score>f`
+    - annotated
+    # Prefer simple looking "template" style tokens like `%{name}`, `%{age}`
+    - template
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: when_needed
@@ -636,71 +969,27 @@ Style/HashSyntax:
 Style/IfUnlessModifier:
   MaxLineLength: 80
 
-Layout/IndentationConsistency:
-  # The difference between `rails` and `normal` is that the `rails` style
-  # prescribes that in classes and modules the `protected` and `private`
-  # modifier keywords shall be indented the same as public methods and that
-  # protected and private members shall be indented one step more than the
-  # modifiers. Other than that, both styles mean that entities on the same
-  # logical depth shall have the same indentation.
-  EnforcedStyle: normal
-  SupportedStyles:
-    - normal
-    - rails
-
-Layout/IndentationWidth:
-  # Number of spaces for each indentation level.
-  Width: 2
-
-# Checks the indentation of the first element in an array literal.
-Layout/IndentArray:
-  # The value `special_inside_parentheses` means that array literals with
-  # brackets that have their opening bracket on the same line as a surrounding
-  # opening round parenthesis, shall have their first element indented relative
-  # to the first position inside the parenthesis.
-  #
-  # The value `consistent` means that the indentation of the first element shall
-  # always be relative to the first position of the line where the opening
-  # bracket is.
-  #
-  # The value `align_brackets` means that the indentation of the first element
-  # shall always be relative to the position of the opening bracket.
-  EnforcedStyle: special_inside_parentheses
-  SupportedStyles:
-    - special_inside_parentheses
-    - consistent
-    - align_brackets
-  # By default, the indentation width from `Style/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
-
-# Checks the indentation of assignment RHS, when on a different line from LHS
-Layout/IndentAssignment:
-  # By default, the indentation width from `Style/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
-
-# Checks the indentation of the first key in a hash literal.
-Layout/IndentHash:
-  # The value `special_inside_parentheses` means that hash literals with braces
-  # that have their opening brace on the same line as a surrounding opening
-  # round parenthesis, shall have their first key indented relative to the
-  # first position inside the parenthesis.
-  #
-  # The value `consistent` means that the indentation of the first key shall
-  # always be relative to the first position of the line where the opening
-  # brace is.
-  #
-  # The value `align_braces` means that the indentation of the first key shall
-  # always be relative to the position of the opening brace.
-  EnforcedStyle: special_inside_parentheses
-  SupportedStyles:
-    - special_inside_parentheses
-    - consistent
-    - align_braces
-  # By default, the indentation width from `Style/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+Style/InverseMethods:
+  Enabled: true
+  # `InverseMethods` are methods that can be inverted by a not (`not` or `!`)
+  # The relationship of inverse methods only needs to be defined in one direction.
+  # Keys and values both need to be defined as symbols.
+  InverseMethods:
+    :any?: :none?
+    :even?: :odd?
+    :==: :!=
+    :=~: :!~
+    :<: :>=
+    :>: :<=
+    # `ActiveSupport` defines some common inverse methods. They are listed below,
+    # and not enabled by default.
+    #:present?: :blank?,
+    #:include?: :exclude?
+  # `InverseBlocks` are methods that are inverted by inverting the return
+  # of the block that is passed to the method
+  InverseBlocks:
+    :select: :reject
+    :select!: :reject!
 
 Style/Lambda:
   EnforcedStyle: line_count_dependent
@@ -709,12 +998,6 @@ Style/Lambda:
     - lambda
     - literal
 
-Layout/SpaceInLambdaLiteral:
-  EnforcedStyle: require_no_space
-  SupportedStyles:
-    - require_no_space
-    - require_space
-
 Style/LambdaCall:
   EnforcedStyle: call
   SupportedStyles:
@@ -722,6 +1005,7 @@ Style/LambdaCall:
     - braces
 
 Style/MethodCallWithArgsParentheses:
+  IgnoreMacros: true
   IgnoredMethods: []
 
 Style/MethodDefParentheses:
@@ -730,12 +1014,6 @@ Style/MethodDefParentheses:
     - require_parentheses
     - require_no_parentheses
     - require_no_parentheses_except_multiline
-
-Naming/MethodName:
-  EnforcedStyle: snake_case
-  SupportedStyles:
-    - snake_case
-    - camelCase
 
 # Checks the grouping of mixins (`include`, `extend`, `prepend`) in `class` and
 # `module` bodies.
@@ -753,82 +1031,41 @@ Style/ModuleFunction:
     - module_function
     - extend_self
 
-Layout/MultilineArrayBraceLayout:
-  EnforcedStyle: symmetrical
+Style/MultilineMemoization:
+  EnforcedStyle: keyword
   SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last element
-    - symmetrical
-    - new_line
-    - same_line
+    - keyword
+    - braces
 
-Layout/MultilineAssignmentLayout:
-  # The types of assignments which are subject to this rule.
-  SupportedTypes:
-    - block
-    - case
-    - class
-    - if
-    - kwbegin
-    - module
-  EnforcedStyle: new_line
+Style/NegatedIf:
+  EnforcedStyle: both
   SupportedStyles:
-    # Ensures that the assignment operator and the rhs are on the same line for
-    # the set of supported types.
-    - same_line
-    # Ensures that the assignment operator and the rhs are on separate lines
-    # for the set of supported types.
-    - new_line
+    # both: prefix and postfix negated `if` should both use `unless`
+    # prefix: only use `unless` for negated `if` statements positioned before the body of the statement
+    # postfix: only use `unless` for negated `if` statements positioned after the body of the statement
+    - both
+    - prefix
+    - postfix
 
-Layout/MultilineHashBraceLayout:
-  EnforcedStyle: symmetrical
-  SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on same line as last element
-    - symmetrical
-    - new_line
-    - same_line
-
-Layout/MultilineMethodCallBraceLayout:
-  EnforcedStyle: symmetrical
-  SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last argument
-    - symmetrical
-    - new_line
-    - same_line
-
-Layout/MultilineMethodCallIndentation:
-  # EnforcedStyle: aligned
-  SupportedStyles:
-    - aligned
-    - indented
-    - indented_relative_to_receiver
-  # By default, the indentation width from Style/IndentationWidth is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
-
-Layout/MultilineMethodDefinitionBraceLayout:
-  EnforcedStyle: symmetrical
-  SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last parameter
-    - symmetrical
-    - new_line
-    - same_line
-
-Layout/MultilineOperationIndentation:
-  EnforcedStyle: aligned
-  SupportedStyles:
-    - aligned
-    - indented
-  # By default, the indentation width from `Style/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+Style/NestedParenthesizedCalls:
+  Whitelist:
+    - be
+    - be_a
+    - be_an
+    - be_between
+    - be_falsey
+    - be_kind_of
+    - be_instance_of
+    - be_truthy
+    - be_within
+    - eq
+    - eql
+    - end_with
+    - include
+    - match
+    - raise_error
+    - respond_to
+    - start_with
 
 Style/Next:
   # With `always` all conditions at the end of an iteration needs to be
@@ -853,6 +1090,8 @@ Style/NonNilCheck:
 
 Style/NumericLiterals:
   MinDigits: 5
+  Strict: false
+  Enabled: false
 
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_with_o
@@ -884,43 +1123,22 @@ Style/ParenthesesAroundCondition:
   AllowSafeAssignment: true
 
 Style/PercentLiteralDelimiters:
+  # Specify the default preferred delimiter for all types with the 'default' key
+  # Override individual delimiters (even with default specified) by specifying
+  # an individual key
   PreferredDelimiters:
-    '%':  ()
-    '%i': ()
-    '%I': ()
-    '%q': ()
-    '%Q': ()
+    default: ()
+    '%i': '()'
+    '%I': '()'
     '%r': '{}'
-    '%s': ()
-    '%w': ()
-    '%W': ()
-    '%x': ()
+    '%w': '()'
+    '%W': '()'
 
 Style/PercentQLiterals:
   EnforcedStyle: lower_case_q
   SupportedStyles:
     - lower_case_q # Use `%q` when possible, `%Q` when necessary
     - upper_case_q # Always use `%Q`
-
-Naming/PredicateName:
-  # Predicate name prefixes.
-  NamePrefix:
-    - is_
-    - has_
-    - have_
-  # Predicate name prefixes that should be removed.
-  NamePrefixBlacklist:
-    - is_
-    - has_
-    - have_
-  # Predicate names which, despite having a blacklisted prefix, or no `?`,
-  # should still be accepted
-  NameWhitelist:
-    - is_a?
-  # Exclude Rspec specs because there is a strong convetion to write spec
-  # helpers in the form of `have_something` or `be_something`.
-  Exclude:
-    - 'spec/**/*'
 
 Style/PreferredHashMethods:
   EnforcedStyle: short
@@ -952,6 +1170,12 @@ Style/RegexpLiteral:
   # are found in the regexp string.
   AllowInnerSlashes: false
 
+Style/ReturnNil:
+  EnforcedStyle: return
+  SupportedStyles:
+    - return
+    - return_nil
+
 Style/SafeNavigation:
   # Safe navigation may cause a statement to start returning `nil` in addition
   # to whatever it used to return.
@@ -979,67 +1203,6 @@ Style/SingleLineBlockParams:
 
 Style/SingleLineMethods:
   AllowIfMethodIsEmpty: true
-
-Layout/SpaceAroundBlockParameters:
-  EnforcedStyleInsidePipes: no_space
-  SupportedStylesInsidePipes:
-    - space
-    - no_space
-
-Layout/SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: space
-  SupportedStyles:
-    - space
-    - no_space
-
-Layout/SpaceAroundOperators:
-  # When `true`, allows most uses of extra spacing if the intent is to align
-  # with an operator on the previous or next line, not counting empty lines
-  # or comment lines.
-  AllowForAlignment: true
-
-Layout/SpaceBeforeBlockBraces:
-  EnforcedStyle: space
-  SupportedStyles:
-    - space
-    - no_space
-
-Layout/SpaceBeforeFirstArg:
-  # When `true`, allows most uses of extra spacing if the intent is to align
-  # things with the previous or next line, not counting empty lines or comment
-  # lines.
-  AllowForAlignment: true
-
-Layout/SpaceInsideBlockBraces:
-  EnforcedStyle: space
-  SupportedStyles:
-    - space
-    - no_space
-  EnforcedStyleForEmptyBraces: no_space
-  SupportedStylesForEmptyBraces:
-    - space
-    - no_space
-  # Space between `{` and `|`. Overrides `EnforcedStyle` if there is a conflict.
-  SpaceBeforeBlockParameters: true
-
-Layout/SpaceInsideHashLiteralBraces:
-  # EnforcedStyle: space
-  SupportedStyles:
-    - space
-    - no_space
-    # 'compact' normally requires a space inside hash braces, with the exception
-    # that successive left braces or right braces are collapsed together
-    - compact
-  EnforcedStyleForEmptyBraces: no_space
-  SupportedStylesForEmptyBraces:
-    - space
-    - no_space
-
-Layout/SpaceInsideStringInterpolation:
-  EnforcedStyle: no_space
-  SupportedStyles:
-    - space
-    - no_space
 
 Style/SpecialGlobalVars:
   EnforcedStyle: use_english_names
@@ -1080,9 +1243,12 @@ Style/StringMethods:
 
 Style/SymbolArray:
   EnforcedStyle: percent
+  MinSize: 0
   SupportedStyles:
     - percent
     - brackets
+  Exclude:
+    - 'db/migrate/**'
 
 Style/SymbolProc:
   # A list of method names to be ignored by the check.
@@ -1098,12 +1264,6 @@ Style/TernaryParentheses:
     - require_no_parentheses
     - require_parentheses_when_complex
   AllowSafeAssignment: true
-
-Layout/TrailingBlankLines:
-  EnforcedStyle: final_newline
-  SupportedStyles:
-    - final_newline
-    - final_blank_line
 
 Style/TrailingCommaInArguments:
   # If `comma`, the cop requires a comma after the last argument, but only for
@@ -1121,7 +1281,7 @@ Style/TrailingCommaInLiteral:
   # hash, but only when each item is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last item of all
   # non-empty array and hash literals.
-  # EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma
@@ -1169,19 +1329,6 @@ Style/TrivialAccessors:
     - to_s
     - to_sym
 
-Naming/VariableName:
-  EnforcedStyle: snake_case
-  SupportedStyles:
-    - snake_case
-    - camelCase
-
-Naming/VariableNumber:
-  EnforcedStyle: normalcase
-  SupportedStyles:
-    - snake_case
-    - normalcase
-    - non_integer
-
 Style/WhileUntilModifier:
   MaxLineLength: 80
 
@@ -1200,6 +1347,14 @@ Style/WordArray:
   # The regular expression `WordRegex` decides what is considered a word.
   WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
 
+Style/YodaCondition:
+  EnforcedStyle: all_comparison_operators
+  SupportedStyles:
+    # check all comparison operators
+    - all_comparison_operators
+    # check only equality operators: `!=` and `==`
+    - equality_operators_only
+
 #################### Metrics ###############################
 
 Metrics/AbcSize:
@@ -1211,6 +1366,11 @@ Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Max: 25
   ExcludedMethods: []
+  Exclude:
+    - 'app/graphql/**/*'
+    - 'spec/**/*'
+    - 'db/migrate/*'
+    - '*.gemspec'
 
 Metrics/BlockNesting:
   CountBlocks: false
@@ -1358,6 +1518,12 @@ Rails/Date:
     - strict
     - flexible
 
+Rails/Delegate:
+  # When set to true, using the target object as a prefix of the
+  # method name without using the `delegate` method will be a
+  # violation. When set to false, this case is legal.
+  EnforceForPrefixed: true
+
 Rails/DynamicFindBy:
   Whitelist:
     - find_by_sql
@@ -1383,6 +1549,10 @@ Rails/FindEach:
     - app/models/**/*.rb
 
 Rails/HasAndBelongsToMany:
+  Include:
+    - app/models/**/*.rb
+
+Rails/HasManyOrHasOneDependent:
   Include:
     - app/models/**/*.rb
 
@@ -1437,6 +1607,12 @@ Rails/UniqBeforePluck:
     - aggressive
   AutoCorrect: false
 
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - production
+
 Rails/SkipsModelValidations:
   Blacklist:
     - decrement!
@@ -1454,3 +1630,9 @@ Rails/SkipsModelValidations:
 Rails/Validation:
   Include:
     - app/models/**/*.rb
+
+Bundler/OrderedGems:
+  TreatCommentsAsGroupSeparators: true
+
+Gemspec/OrderedDependencies:
+  TreatCommentsAsGroupSeparators: true

--- a/.rubocop_disabled.yml
+++ b/.rubocop_disabled.yml
@@ -59,6 +59,9 @@ Style/DocumentationMethod:
     - 'spec/**/*'
     - 'test/**/*'
 
+Style/DoubleNegation:
+  Enabled: false
+
 Style/ImplicitRuntimeError:
   Description: >-
                  Use `raise` or `fail` with an explicit exception class and

--- a/.rubocop_enabled.yml
+++ b/.rubocop_enabled.yml
@@ -25,7 +25,7 @@ Layout/AlignParameters:
                  Align the parameters of a method call if they span more
                  than one line.
   StyleGuide: '#no-double-indent'
-  Enabled: true
+  Enabled: false
 
 Layout/BlockEndNewline:
   Description: 'Put end statement of multiline block on its own line.'
@@ -307,6 +307,7 @@ Layout/SpaceInsideHashLiteralBraces:
   Description: "Use spaces inside hash literal braces - or don't."
   StyleGuide: '#spaces-operators'
   Enabled: true
+  EnforcedStyle: no_space
 
 Layout/SpaceInsideParens:
   Description: 'No spaces after ( or before ).'
@@ -499,11 +500,20 @@ Style/CommentAnnotation:
   StyleGuide: '#annotate-keywords'
   Enabled: true
 
+Style/CommentedKeyword:
+  Description: 'Do not place comments on the same line as certain keywords.'
+  Enabled: true
+
 Style/ConditionalAssignment:
   Description: >-
                  Use the return value of `if` and `case` statements for
                  assignment to a variable and variable comparison instead
                  of assigning that variable inside of each branch.
+  Enabled: true
+
+Style/DateTime:
+  Description: 'Use Date or Time over DateTime.'
+  StyleGuide: '#date--time'
   Enabled: true
 
 Style/DefWithParentheses:
@@ -527,7 +537,7 @@ Style/Documentation:
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   StyleGuide: '#no-bang-bang'
-  Enabled: true
+  Enabled: false
 
 Style/EachForSimpleLoop:
   Description: >-
@@ -792,7 +802,7 @@ Style/NumericLiterals:
                  Add underscores to large numeric literals to improve their
                  readability.
   StyleGuide: '#underscores-in-numerics'
-  Enabled: true
+  Enabled: false
 
 Style/NumericLiteralPrefix:
   Description: 'Use smallcase prefixes for numeric literals.'
@@ -954,6 +964,11 @@ Style/StabbyLambdaParentheses:
   StyleGuide: '#stabby-lambda-with-args'
   Enabled: true
 
+Style/StderrPuts:
+  Description: 'Use `warn` instead of `$stderr.puts`.'
+  StyleGuide: '#warn'
+  Enabled: true
+
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
   StyleGuide: '#consistent-string-literals'
@@ -985,6 +1000,10 @@ Style/SymbolProc:
 
 Style/TernaryParentheses:
   Description: 'Checks for use of parentheses around ternary conditions.'
+  Enabled: true
+
+Style/MixinUsage:
+  Description: 'Checks that `include`, `extend` and `prepend` exists at the top level.'
   Enabled: true
 
 Style/TrailingCommaInArguments:
@@ -1264,7 +1283,7 @@ Lint/InterpolationCheck:
   Description: 'Raise warning for interpolation in single q strs'
   Enabled: true
 
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: true
 
@@ -1325,6 +1344,16 @@ Lint/RedundantWithIndex:
   Description: 'Checks for redundant `with_index`.'
   Enabled: true
 
+Lint/RedundantWithObject:
+  Description: 'Checks for redundant `with_object`.'
+  Enabled: true
+
+Lint/RegexpAsCondition:
+  Description: >-
+                 Do not use regexp literal as a condition.
+                 The regexp literal matches `$_` implicitly.
+  Enabled: true
+
 Lint/RequireParentheses:
   Description: >-
                  Use parentheses in the method call to avoid confusion
@@ -1383,6 +1412,10 @@ Lint/UnneededDisable:
                  Checks for rubocop:disable comments that can be removed.
                  Note: this cop is not disabled when disabling all cops.
                  It must be explicitly disabled.
+  Enabled: true
+
+Lint/UnneededRequireStatement:
+  Description: 'Checks for unnecessary `require` statement.'
   Enabled: true
 
 Lint/UnneededSplatExpansion:
@@ -1776,6 +1809,10 @@ Rails/UniqBeforePluck:
   Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: true
 
+Rails/UnknownEnv:
+  Description: 'Use correct environment name.'
+  Enabled: true
+
 Rails/SkipsModelValidations:
   Description: >-
                  Use methods that skips model validations with caution.
@@ -1843,3 +1880,10 @@ Bundler/OrderedGems:
   Include:
     - '**/Gemfile'
     - '**/gems.rb'
+
+Gemspec/OrderedDependencies:
+  Description: >-
+                 Dependencies in the gemspec should be alphabetically sorted.
+  Enabled: true
+  Include:
+    - '**/*.gemspec'

--- a/.rubocop_modified.yml
+++ b/.rubocop_modified.yml
@@ -1,8 +1,9 @@
 Metrics/BlockLength:
   Exclude:
-    - 'ontohub-models.gemspec'
+    - 'app/graphql/**/*'
     - 'spec/**/*'
     - 'db/migrate/*'
+    - '*.gemspec'
 
 Layout/AlignParameters:
   Enabled: false
@@ -13,8 +14,23 @@ Layout/DotPosition:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: ()
+    '%i': '()'
+    '%I': '()'
+    '%r': '{}'
+    '%w': '()'
+    '%W': '()'
+
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
 
 Style/SymbolArray:
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rubocop (0.50.0)
+    rubocop (0.51.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
@@ -263,7 +263,7 @@ DEPENDENCIES
   rake (~> 12.1.0)
   rspec (~> 3.6.0)
   rspec-rails (~> 3.6.0)
-  rubocop (~> 0.50.0)
+  rubocop (~> 0.51.0)
 
 BUNDLED WITH
    1.15.4

--- a/Rakefile
+++ b/Rakefile
@@ -30,5 +30,5 @@ begin
   RSpec::Core::RakeTask.new(:spec)
   task default: :spec
 rescue LoadError
-  $stderr.puts 'RSpec not available. Not running specs.'
+  warn 'RSpec not available. Not running specs.'
 end

--- a/app/models/public_key.rb
+++ b/app/models/public_key.rb
@@ -10,7 +10,7 @@ class PublicKey < Sequel::Model
   end
 
   def validate
-    validates_presence [:key, :name, :user]
+    validates_presence %i(key name user)
 
     if new? && PublicKey.find(user_id: user_id, name: name)
       errors.add(:name, 'is already taken')

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -36,7 +36,7 @@ class Repository < Sequel::Model
       repository_membership.role = role
       repository_membership.save
     else
-      RepositoryMembership.new(member: member, repository: self, role: role).save
+      RepositoryMembership.create(member: member, repository: self, role: role)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 # The class representing an actual user
+# rubocop:disable Metrics/ClassLength
+# This class cannot be shortened by moving the associations into an
+# ActiveSupport::Concern because then, Sequel cannot define the association
+# methods.
 class User < OrganizationalUnit
+  # rubocop:enable Metrics/ClassLength
   # Devise workaround: This allows the user to be authenticated by a :name
   # parameter, that is actually the slug. The public API expects to receive
   # the slug as :name while devise expects the slug as :slug.
@@ -106,7 +111,9 @@ class User < OrganizationalUnit
       or(Sequel[:repositories][:owner_id] => id)
   end), class: Repository
 
+  # rubocop:disable Metrics/MethodLength
   def validate
+    # rubocop:enable Metrics/MethodLength
     validates_includes %w(admin user), :role
     validates_format(Devise.email_regexp, :email)
     validates_unique(:email)

--- a/lib/ontohub-models.rb
+++ b/lib/ontohub-models.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 # frozen_string_literal: true
 
 require 'ontohub-models/engine'

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -5,7 +5,11 @@ namespace :db do
   task :recreate do
     begin
       Rake::Task['db:drop'].invoke
-    rescue Sequel::DatabaseConnectionError => e
+      # rubocop:disable Lint/HandleExceptions
+      # If the database does not yet exist, we don't want to fail.
+      # We cannot check the error message because of different locales.
+    rescue Sequel::DatabaseConnectionError
+      # rubocop:enable Lint/HandleExceptions
     end
     Rake::Task['db:create'].invoke
     Rake::Task['db:migrate'].invoke

--- a/ontohub-models.gemspec
+++ b/ontohub-models.gemspec
@@ -27,14 +27,14 @@ Gem::Specification.new do |s|
   end
 
   # Runtime dependencies
-  s.add_dependency 'rails', '~> 5.1.4'
-  s.add_dependency 'sequel', '~> 4.49.0'
-  s.add_dependency 'sequel_pg', '~> 1.7.1'
-  s.add_dependency 'sequel_postgresql_triggers', '~> 1.3.0'
-  s.add_dependency 'sequel-rails', '~> 0.9.17'
   s.add_dependency 'chewy', '~> 0.10.1'
   s.add_dependency 'devise', '~> 4.3.0'
+  s.add_dependency 'rails', '~> 5.1.4'
+  s.add_dependency 'sequel', '~> 4.49.0'
   s.add_dependency 'sequel-devise', '~> 0.0.11'
+  s.add_dependency 'sequel-rails', '~> 0.9.17'
+  s.add_dependency 'sequel_pg', '~> 1.7.1'
+  s.add_dependency 'sequel_postgresql_triggers', '~> 1.3.0'
 
   # General Development
   s.add_development_dependency 'bundler', '~> 1.11'
@@ -53,11 +53,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '~> 3.6.0'
 
   # CI services
-  s.add_development_dependency 'rubocop', '~> 0.50.0'
   s.add_development_dependency 'codecov', '~> 0.1.10'
+  s.add_development_dependency 'rubocop', '~> 0.51.0'
 
   # We want to have these in the production environment as well in case we need
   # to debug the application:
-  s.add_dependency 'pry', '~> 0.11.0'
   s.add_dependency 'awesome_print', '~> 1.8.0'
+  s.add_dependency 'pry', '~> 0.11.0'
 end


### PR DESCRIPTION
This fixes the Rubocop config and the offences. I use exactly the same config for the backend, models and HetsAgent, meaning there are some superfluous excludes in each config, but this makes it easier to maintain the configs.