### PR TITLE
Ontohub backend: 181 Add API keys

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# The API key model
+class ApiKey < Sequel::Model
+  DIGEST = 'SHA256'
+  SALT = 'Ontohub API Key'
+
+  plugin :devise
+  devise
+
+  class << self
+    def verify(secret, user_key)
+      ApiKey.first(key: digest(secret, user_key))
+    end
+
+    # Generates a unique API key. Returns a hash with :raw and :encoded keys.
+    # The :encoded value needs to be saved in the database.
+    # The :raw value is the key that needs to be passed to the client.
+    def generate(secret, length)
+      loop do
+        raw_key = generate_raw_key(length)
+        encoded_key = digest(secret, raw_key)
+        if ApiKey.where(key: encoded_key).empty?
+          break {encoded: encoded_key, raw: raw_key}
+        end
+      end
+    end
+
+    def digest(secret, raw_key)
+      OpenSSL::HMAC.hexdigest(DIGEST, key(secret), raw_key)
+    end
+
+    protected
+
+    def key(secret)
+      generator(secret).generate_key(SALT)
+    end
+
+    def generator(secret)
+      ActiveSupport::CachingKeyGenerator.
+        new(ActiveSupport::KeyGenerator.new(secret))
+    end
+
+    def generate_raw_key(length)
+      real_length = (length * 3) / 4
+      pre_key = SecureRandom.urlsafe_base64(real_length)
+      # Replace characters that look alike in some fonts
+      pre_key.tr('lIO0', 'sxyz')
+    end
+  end
+end

--- a/db/migrate/20160902111740_initial_schema.rb
+++ b/db/migrate/20160902111740_initial_schema.rb
@@ -135,6 +135,15 @@ Sequel.migration do
       column :updated_at, DateTime, null: false # This is set by a trigger
     end
 
+    create_table :api_keys do
+      primary_key :id
+      column :key, String, null: false, unique: true
+      column :comment, String, null: true
+
+      column :created_at, DateTime, null: false # This is set by a trigger
+      column :updated_at, DateTime, null: false # This is set by a trigger
+    end
+
     create_table :url_mappings do
       primary_key :id
       foreign_key :repository_id, :repositories,

--- a/spec/factories/api_keys_factory.rb
+++ b/spec/factories/api_keys_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_key do
+    key { Faker::Crypto.sha256 }
+    comment { nil }
+  end
+end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApiKey do
+  context 'timestamps' do
+    subject { build(:api_key) }
+    it_behaves_like 'an object with timestamps'
+  end
+
+  context '.generate' do
+    let(:secret) { Faker::Crypto.md5 }
+    let(:length) { 10 }
+    let(:key) { ApiKey.generate(secret, length) }
+
+    it 'contains an encoded and a raw key' do
+      expect(key).to match(encoded: be_present, raw: be_present)
+    end
+
+    it 'creates an encoded key that is sha256 digested' do
+      expect(key[:encoded]).to match(/[0-9a-f]{64}/)
+    end
+
+    (11..14).each do |key_length|
+      context "with length #{key_length}" do
+        let(:length) { key_length }
+
+        it 'creates a raw key with a fitting length' do
+          expect(key[:raw].length).to be_between(length - 1, length).inclusive
+        end
+      end
+    end
+  end
+
+  context '.verify' do
+    let(:secret) { Faker::Crypto.md5 }
+    let(:length) { 10 }
+    let(:key) { ApiKey.generate(secret, length) }
+    let!(:api_key) { create(:api_key, key: key[:encoded]) }
+
+    shared_examples 'it is invalid' do
+      it 'does not verify' do
+        expect(ApiKey.verify(user_secret, user_key)).to be(nil)
+      end
+    end
+
+    shared_examples 'it is valid' do
+      it 'validates' do
+        expect(ApiKey.verify(user_secret, user_key)).to eq(api_key)
+      end
+    end
+
+    context 'when the secret is valid' do
+      let(:user_secret) { secret }
+
+      context 'when the key is valid' do
+        let(:user_key) { key[:raw] }
+        include_examples 'it is valid'
+      end
+
+      context 'when the key is invalid' do
+        let(:user_key) { "bad-#{key[:raw]}" }
+        include_examples 'it is invalid'
+      end
+    end
+
+    context 'when the secret is invalid' do
+      let(:user_secret) { "bad-#{secret}" }
+
+      context 'when the key is valid' do
+        let(:user_key) { key[:raw] }
+        include_examples 'it is invalid'
+      end
+
+      context 'when the key is invalid' do
+        let(:user_key) { "bad-#{key[:raw]}" }
+        include_examples 'it is invalid'
+      end
+    end
+  end
+end

--- a/spec/models/consistency_check_attempt_spec.rb
+++ b/spec/models/consistency_check_attempt_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ConsistencyCheckAttempt, type: :model do
 
   context 'superclass' do
     subject { create(:consistency_check_attempt) }
-    it_behaves_like 'a reasoning_attempt', :consistency_check_attempt
+    it_behaves_like 'a reasoning_attempt'
 
     context 'oms' do
       it_behaves_like('it has a', :oms, OMS)

--- a/spec/models/proof_attempt_spec.rb
+++ b/spec/models/proof_attempt_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProofAttempt, type: :model do
 
   context 'superclass' do
     subject { create(:proof_attempt) }
-    it_behaves_like 'a reasoning_attempt', :proof_attempt
+    it_behaves_like 'a reasoning_attempt'
 
     context 'conjecture' do
       it_behaves_like('it has a', :conjecture, Conjecture)

--- a/spec/shared_examples/a_reasoning_attempt.rb
+++ b/spec/shared_examples/a_reasoning_attempt.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples 'a reasoning_attempt' do |factory|
+RSpec.shared_examples 'a reasoning_attempt' do
   context 'associations' do
     before { subject.save }
 


### PR DESCRIPTION
This is the models-part of https://github.com/ontohub/ontohub-backend/issues/181. 

I'm not sure if we want to have API keys separate from a user (i.e. no `many_to one :user` association on `ApiKey`).

Pro:
 * We don't need a user only for Hets.
 * In the future, we could set fine-grained permissions on API keys.

Con:
  The authorisation is more complicated because we must differentiate whether the `current_user` is a `User` or an `ApiKey`. We wouldn't need this if we tied each `ApiKey` directly to a `User` which then inherited its permissions.

I feel like we should go with the proposed implementation, because we only use them for Hets at this moment. Later, we could associate them with a User and allow for fine-grained permissions. Then, we would need to create a Hets-User, of course.