### PR TITLE
Replace find by first.

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,6 +20,6 @@ class Organization < OrganizationalUnit
   end
 
   def remove_member(member)
-    OrganizationMembership.find(member: member, organization: self).destroy
+    OrganizationMembership.first(member: member, organization: self).destroy
   end
 end

--- a/app/models/public_key.rb
+++ b/app/models/public_key.rb
@@ -12,7 +12,7 @@ class PublicKey < Sequel::Model
   def validate
     validates_presence %i(key name user)
 
-    if new? && PublicKey.find(user_id: user_id, name: name)
+    if new? && PublicKey.first(user_id: user_id, name: name)
       errors.add(:name, 'is already taken')
     end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -30,8 +30,8 @@ class Repository < Sequel::Model
   end
 
   def add_member(member, role = 'read')
-    repository_membership = RepositoryMembership.find(member: member,
-                                                      repository: self)
+    repository_membership = RepositoryMembership.first(member: member,
+                                                       repository: self)
     if repository_membership
       repository_membership.role = role
       repository_membership.save
@@ -41,6 +41,6 @@ class Repository < Sequel::Model
   end
 
   def remove_member(member)
-    RepositoryMembership.find(member: member, repository: self).destroy
+    RepositoryMembership.first(member: member, repository: self).destroy
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -41,7 +41,7 @@ class Signature < Sequel::Model
   end
 
   def remove_symbol(symbol)
-    SignatureSymbol.find(signature_id: id,
-                         symbol_id: symbol.id).destroy
+    SignatureSymbol.first(signature_id: id,
+                          symbol_id: symbol.id).destroy
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,7 +132,7 @@ class User < OrganizationalUnit
   # plugin, but this method is not used very often, so the plugin would be
   # overhead.
   def email_was
-    self.class.find(id: id).email
+    self.class.first(id: id).email
   end
 
   # Devise Trackable requires these two attributes to be defined, but we do not

--- a/config/initializers/core_extensions/sequel/model/orm_adapter/sequel.rb
+++ b/config/initializers/core_extensions/sequel/model/orm_adapter/sequel.rb
@@ -8,7 +8,7 @@ class Sequel::Model
   class OrmAdapter < ::OrmAdapter::Base
     def get(id)
       column = Sequel[klass.table_name][klass.primary_key]
-      klass.find(wrap_key(column => id))
+      klass.first(wrap_key(column => id))
     end
   end
   # :nocov:

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -103,13 +103,13 @@ RSpec.describe Repository, type: :model do
 
       it 'changes role of existent member' do
         subject.add_member(member, 'write')
-        expect(RepositoryMembership.find(member: member, repository: subject).
+        expect(RepositoryMembership.first(member: member, repository: subject).
           role).to match('write')
       end
 
       it 'removes member' do
         subject.remove_member(member)
-        expect(RepositoryMembership.find(member: member, repository: subject)).
+        expect(RepositoryMembership.first(member: member, repository: subject)).
           to be_falsy
       end
     end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Signature do
           end
 
           it 'marks the symbol correctly' do
-            expect(SignatureSymbol.find(signature: subject, symbol: symbol).
+            expect(SignatureSymbol.first(signature: subject, symbol: symbol).
                      imported).
               to be(imported)
           end
@@ -128,7 +128,7 @@ RSpec.describe Signature do
       end
 
       it 'removes the association row' do
-        expect(SignatureSymbol.find(signature: subject, symbol: symbol)).
+        expect(SignatureSymbol.first(signature: subject, symbol: symbol)).
           to be(nil)
       end
     end

--- a/spec/shared_examples/being_nullified_with_deletion_of_the_association.rb
+++ b/spec/shared_examples/being_nullified_with_deletion_of_the_association.rb
@@ -4,8 +4,9 @@
 RSpec.shared_examples('being nullified with deletion of the association') do |association|
   # rubocop:enable Metrics/LineLength
   it "is set null when the #{association} is deleted" do
+    id = subject.id
     expect { subject.public_send(association).delete }.
-      to change { subject.class.find(id: subject.id).public_send(association) }.
+      to change { subject.class.first(id: id).public_send(association) }.
       to(nil)
   end
 end


### PR DESCRIPTION
Sequel encourages us [to use `Model.[]` or `Model.first` instead of `find`](http://sequel.jeremyevans.net/rdoc/classes/Sequel/Model/ClassMethods.html#method-i-find). This pull request replaces all `find` by `first`.