### PR TITLE
Remove Postgres Enumeration Types.

### DIFF
--- a/app/models/conjecture.rb
+++ b/app/models/conjecture.rb
@@ -2,5 +2,17 @@
 
 # The Conjecture model
 class Conjecture < Sentence
+  EVALUATION_STATES = %w(not_yet_enqueued enqueued processing
+                         finished_successfully finished_unsuccessfully).freeze
+  REASONING_STATUSES ||= %w(OPN ERR UNK RSO THM CSA CSAS CONTR).freeze
+
+  plugin :validation_helpers
+
   one_to_many :proof_attempts
+
+  def validate
+    validates_includes EVALUATION_STATES, :evaluation_state
+    validates_includes REASONING_STATUSES, :reasoning_status
+    super
+  end
 end

--- a/app/models/file_version.rb
+++ b/app/models/file_version.rb
@@ -3,6 +3,8 @@
 # Represents a specific version of a file. There exists only a FileVersion for
 # a git commit that actually changes the file.
 class FileVersion < Sequel::Model
+  EVALUATION_STATES = %w(not_yet_enqueued enqueued processing
+                         finished_successfully finished_unsuccessfully).freeze
   plugin :validation_helpers
 
   many_to_one :repository
@@ -13,6 +15,7 @@ class FileVersion < Sequel::Model
     validates_presence :commit_sha
     validates_format(/\A[a-f0-9]{40}\z/, :commit_sha)
     validates_presence :path
+    validates_includes EVALUATION_STATES, :evaluation_state if evaluation_state
     super
   end
 end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -2,10 +2,33 @@
 
 # A mapping uses a signature morphism to map an OMS to another
 class Mapping < LocIdBase
+  ORIGINS = %w(see_target see_source test dg_link_verif dg_implies_link
+               dg_link_extension dg_link_translation dg_link_closed_lenv
+               dg_link_imports dg_link_intersect dg_link_morph dg_link_inst
+               dg_link_inst_arg dg_link_view dg_link_align dg_link_fit_view
+               dg_link_fit_view_imp dg_link_proof dg_link_flattening_union
+               dg_link_flattening_rename dg_link_refinement).freeze
+
+  TYPES = %w(local_def local_thm_open local_thm_proved
+             global_def global_thm_open global_thm_proved
+             hiding_def
+             free_def cofree_def np_free_def minimize_def
+             hiding_open hiding_proved
+             free_open cofree_open np_free_open minimize_open
+             free_proved cofree_proved np_free_proved minimize_proved).freeze
+
+  plugin :validation_helpers
+
   many_to_one :source, class: OMS
   many_to_one :target, class: OMS
   many_to_one :signature_morphism
   many_to_one :conservativity_status
   many_to_one :freeness_parameter_oms, class: OMS
   many_to_one :freeness_parameter_language, class: Language
+
+  def validate
+    validates_includes ORIGINS, :origin
+    validates_includes TYPES, :type
+    super
+  end
 end

--- a/app/models/oms.rb
+++ b/app/models/oms.rb
@@ -2,6 +2,16 @@
 
 # The OMS model
 class OMS < LocIdBase
+  ORIGINS = %w(dg_empty dg_basic dg_basic_spec dg_extension dg_logic_coercion
+               dg_translation dg_union dg_intersect dg_extract dg_restriction
+               dg_reveal_translation free cofree np_free minimize dg_local
+               dg_closed dg_logic_qual dg_data dg_formal_params
+               dg_verification_generic dg_imports dg_inst dg_fit_spec
+               dg_fit_view dg_proof dg_normal_form dg_integrated_scc
+               dg_flattening dg_alignment dg_test).freeze
+
+  plugin :validation_helpers
+
   many_to_one :document
   many_to_one :language
   many_to_one :logic
@@ -50,4 +60,9 @@ class OMS < LocIdBase
             join_type: :inner, select: false).
       where(Sequel[:oms][:id] => id)
   end), class: Repository
+
+  def validate
+    validates_includes ORIGINS, :origin
+    super
+  end
 end

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -2,12 +2,14 @@
 
 # The class representing an Organization Membership
 class OrganizationMembership < Sequel::Model
+  ROLES = %w(admin write read).freeze
+
   plugin :validation_helpers
 
   many_to_one :member, class: User
   many_to_one :organization
 
   def validate
-    validates_includes %w(admin write read), :role
+    validates_includes ROLES, :role
   end
 end

--- a/app/models/reasoning_attempt.rb
+++ b/app/models/reasoning_attempt.rb
@@ -2,10 +2,22 @@
 
 # The ReasoningAttempt model
 class ReasoningAttempt < Sequel::Model
+  EVALUATION_STATES = %w(not_yet_enqueued enqueued processing
+                         finished_successfully finished_unsuccessfully).freeze
+  REASONING_STATUSES ||= %w(OPN ERR UNK RSO THM CSA CSAS).freeze
+
+  plugin :validation_helpers
+
   plugin :class_table_inheritance, key: :kind, alias: :reasoning_attempts
 
   many_to_one :reasoner_configuration
   many_to_one :used_reasoner, class: Reasoner
   one_to_many :generated_axioms
   one_to_one :reasoner_output
+
+  def validate
+    validates_includes EVALUATION_STATES, :evaluation_state
+    validates_includes REASONING_STATUSES, :reasoning_status
+    super
+  end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -3,6 +3,8 @@
 # The Repository model groups libraries and exposes the basic git functinoality.
 class Repository < Sequel::Model
   SLUG_BLACKLIST = %w(repositories organizations members settings).freeze
+  CONTENT_TYPES = %w(ontology model specification mathematical).freeze
+  REMOTE_TYPES = %(fork mirror).freeze
 
   plugin :validation_helpers
 
@@ -31,11 +33,10 @@ class Repository < Sequel::Model
     end
     validates_presence :owner
     validates_presence :public_access
-    validates_includes %w(ontology model specification mathematical),
-      :content_type
+    validates_includes CONTENT_TYPES, :content_type
     validates_presence :remote_type if remote_address.present?
     validates_presence :remote_address if remote_type.present?
-    validates_includes %(fork mirror), :remote_type unless remote_type.nil?
+    validates_includes REMOTE_TYPES, :remote_type unless remote_type.nil?
     super
   end
 

--- a/app/models/repository_membership.rb
+++ b/app/models/repository_membership.rb
@@ -2,12 +2,14 @@
 
 # The class representing an Repository Membership
 class RepositoryMembership < Sequel::Model
+  ROLES = %w(admin write read).freeze
+
   plugin :validation_helpers
 
-  many_to_one :repository
   many_to_one :member, class: User
+  many_to_one :repository
 
   def validate
-    validates_includes %w(admin write read), :role
+    validates_includes ROLES, :role
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < OrganizationalUnit
     super(conditions)
   end
 
+  GLOBAL_ROLES = %w(admin user).freeze
+
   plugin :devise
   devise :database_authenticatable, :registerable, :confirmable, :recoverable,
     :lockable, :trackable
@@ -114,7 +116,7 @@ class User < OrganizationalUnit
   # rubocop:disable Metrics/MethodLength
   def validate
     # rubocop:enable Metrics/MethodLength
-    validates_includes %w(admin user), :role
+    validates_includes GLOBAL_ROLES, :role
     validates_format(Devise.email_regexp, :email)
     validates_unique(:email)
     validates_presence(:password) if new?

--- a/db/migrate/20160902111740_initial_schema.rb
+++ b/db/migrate/20160902111740_initial_schema.rb
@@ -42,15 +42,23 @@ Sequel.migration do
                      after: true)
     end
 
-    extension :pg_enum
+    # Enums are disabled because the Haskell SQL library "persistent", which
+    # Hets uses, cannot read enumeration types from the database. As soon as
+    # https://github.com/yesodweb/persistent/issues/264 is fixed, enums can be
+    # used again. Until then, every enum is replaced by a String with collation
+    # "C".  If more models that could use enums are added, add the accompanying
+    # enums as well, but comment them out and leave a note about the enum type.
+    # extension :pg_enum
 
-    create_enum :organizational_unit_kind_type,
-      %w(User Organization)
+    # create_enum :organizational_unit_kind_type,
+    #   %w(User Organization)
 
     create_table :organizational_units do
       primary_key :id
       # Kind of record - for class table inheritance
-      column :kind, :organizational_unit_kind_type, null: false
+      # This is actually a :organizational_unit_kind_type, but replaced by
+      # String for compatibility reasons.
+      column :kind, String, collate: '"C"', null: false
 
       column :slug, String, collate: '"C"', null: false, unique: true
 
@@ -61,8 +69,8 @@ Sequel.migration do
     end
 
     # User is an OrganizationalUnit
-    create_enum :global_role,
-      %w(admin user)
+    # create_enum :global_role,
+    #   %w(admin user)
 
     create_table :users do
       primary_key :id
@@ -100,7 +108,9 @@ Sequel.migration do
       # column :current_sign_in_ip, String
       # column :last_sign_in_ip, String
 
-      column :role, :global_role, null: false, default: 'user'
+      # This is actually a :global_role, but replaced by String for
+      # compatibility reasons.
+      column :role, String, collate: '"C"', null: false, default: 'user'
     end
 
     create_table :public_keys do
@@ -126,8 +136,8 @@ Sequel.migration do
       column :description, String, null: false
     end
 
-    create_enum :organization_role,
-      %w(admin write read)
+    # create_enum :organization_role,
+    #   %w(admin write read)
 
     create_table :organization_memberships do
       primary_key [:organization_id, :member_id]
@@ -135,14 +145,16 @@ Sequel.migration do
                   null: false, index: true, on_delete: :cascade
       foreign_key :member_id, :users,
                   null: false, index: true, on_delete: :cascade
-      column :role, :organization_role, null: false, default: 'read'
+      # This is actually a :organization_role, but replaced by String for
+      # compatibility reasons.
+      column :role, String, collate: '"C"', null: false, default: 'read'
     end
 
-    create_enum :repository_content_type,
-      %w(ontology model specification mathematical)
+    # create_enum :repository_content_type,
+    #   %w(ontology model specification mathematical)
 
-    create_enum :repository_remote_type_type,
-      %w(fork mirror)
+    # create_enum :repository_remote_type_type,
+    #   %w(fork mirror)
 
     create_table :repositories do
       primary_key :id
@@ -153,9 +165,13 @@ Sequel.migration do
       column :name, String, null: false
       column :description, :text, null: true
       column :public_access, TrueClass, null: false
-      column :content_type, :repository_content_type, null: false
+      # This is actually a :repository_content_type, but replaced by String for
+      # compatibility reasons.
+      column :content_type, String, collate: '"C"', null: false
       column :remote_address, String, null: true
-      column :remote_type, :repository_remote_type_type, null: true
+      # This is actually a repository_remote_type_type, but replaced by String
+      # for compatibility reasons.
+      column :remote_type, String, collate: '"C"', null: true
       column :synchronized_at, DateTime, null: true
 
       column :created_at, DateTime, null: false # This is set by a trigger
@@ -185,8 +201,8 @@ Sequel.migration do
 
     create_trigger_to_set_number(:url_mappings, :repository_id)
 
-    create_enum :repository_role,
-      %w(admin write read)
+    # create_enum :repository_role,
+    #   %w(admin write read)
 
     create_table :repository_memberships do
       primary_key [:repository_id, :member_id]
@@ -194,12 +210,14 @@ Sequel.migration do
                   null: false, index: true, on_delete: :cascade
       foreign_key :member_id, :users,
                   null: false, index: true, on_delete: :cascade
-      column :role, :repository_role, null: false, default: 'read'
+      # This is actually a :repository_role, but replaced by String for
+      # compatibility reasons.
+      column :role, String, collate: '"C"', null: false, default: 'read'
     end
 
-    create_enum :evaluation_state_type,
-      %w(not_yet_enqueued enqueued processing
-         finished_successfully finished_unsuccessfully)
+    # create_enum :evaluation_state_type,
+    #   %w(not_yet_enqueued enqueued processing
+    #      finished_successfully finished_unsuccessfully)
 
     create_table :file_versions do
       primary_key :id, type: :bigserial
@@ -210,7 +228,9 @@ Sequel.migration do
       column :commit_sha, String, null: false
       column :path, String, null: false
 
-      column :evaluation_state, :evaluation_state_type,
+      # This is actually a :evaluation_state_type, but replaced by String for
+      # compatibility reasons.
+      column :evaluation_state, String, collate: '"C"',
         null: false,
         default: 'not_yet_enqueued'
 
@@ -227,9 +247,9 @@ Sequel.migration do
       column :queried_sha, String, null: false, index: true
     end
 
-    create_enum :loc_id_base_kind_type,
-      %w(NativeDocument Library OMS Mapping OpenConjecture Theorem
-         CounterTheorem Axiom Symbol)
+    # create_enum :loc_id_base_kind_type,
+    #   %w(NativeDocument Library OMS Mapping OpenConjecture Theorem
+    #      CounterTheorem Axiom Symbol)
 
     create_table :loc_id_bases do
       # We use bigint/bigserial for the id because there will be many symbols
@@ -238,7 +258,9 @@ Sequel.migration do
       foreign_key :file_version_id, :file_versions,
                   type: :bigint, null: false, on_delete: :cascade
       # Kind of record - for class table inheritance
-      column :kind, :loc_id_base_kind_type, null: false
+      # This is actually a :loc_id_base_kind_type, but replaced by String for
+      # compatibility reasons.
+      column :kind, String, collate: '"C"', null: false
       column :loc_id, String, collate: '"C"', null: false
 
       column :created_at, DateTime, null: false # This is set by a trigger
@@ -376,8 +398,8 @@ Sequel.migration do
       column :end_column, Integer, null: true
     end
 
-    create_enum :diagnosis_kind_type,
-      %w(Error Warn Hint Debug)
+    # create_enum :diagnosis_kind_type,
+    #   %w(Error Warn Hint Debug)
 
     create_table :diagnoses do
       primary_key :id
@@ -386,7 +408,9 @@ Sequel.migration do
       foreign_key :file_range_id, :file_ranges,
                   type: :bigint, null: true, on_delete: :set_null
       column :number, Integer, null: false # This is set by a trigger
-      column :kind, :diagnosis_kind_type, null: false
+      # This is actually a :diagnosis_kind_type, but replaced by String for
+      # compatibility reasons.
+      column :kind, String, collate: '"C"', null: false
       column :text, String, null: false
 
       index [:file_version_id, :number], null: false, unique: true
@@ -394,13 +418,13 @@ Sequel.migration do
 
     create_trigger_to_set_number(:diagnoses, :file_version_id)
 
-    create_enum :oms_origin_type,
-      %w(dg_empty dg_basic dg_basic_spec dg_extension dg_logic_coercion
-         dg_translation dg_union dg_intersect dg_extract dg_restriction
-         dg_reveal_translation free cofree np_free minimize dg_local dg_closed
-         dg_logic_qual dg_data dg_formal_params dg_verification_generic
-         dg_imports dg_inst dg_fit_spec dg_fit_view dg_proof dg_normal_form
-         dg_integrated_scc dg_flattening dg_alignment dg_test)
+    # create_enum :oms_origin_type,
+    #   %w(dg_empty dg_basic dg_basic_spec dg_extension dg_logic_coercion
+    #      dg_translation dg_union dg_intersect dg_extract dg_restriction
+    #      dg_reveal_translation free cofree np_free minimize dg_local dg_closed
+    #      dg_logic_qual dg_data dg_formal_params dg_verification_generic
+    #      dg_imports dg_inst dg_fit_spec dg_fit_view dg_proof dg_normal_form
+    #      dg_integrated_scc dg_flattening dg_alignment dg_test)
 
     # OMS is a LocIdBase
     create_table :oms do
@@ -433,27 +457,29 @@ Sequel.migration do
       column :name_extension_index, Integer, null: false
       # The description is *not* managed by Hets
       column :description, String, null: true
-      column :origin, :oms_origin_type, null: false
+      # This is actually a :oms_origin_type, but replaced by String for
+      # compatibility reasons.
+      column :origin, String, collate: '"C"', null: false
       column :label_has_hiding, TrueClass, null: false
       column :label_has_free, TrueClass, null: false
     end
 
-    create_enum :mapping_origin_type,
-      %w(see_target see_source test dg_link_verif dg_implies_link
-         dg_link_extension dg_link_translation dg_link_closed_lenv
-         dg_link_imports dg_link_intersect dg_link_morph dg_link_inst
-         dg_link_inst_arg dg_link_view dg_link_align dg_link_fit_view
-         dg_link_fit_view_imp dg_link_proof dg_link_flattening_union
-         dg_link_flattening_rename dg_link_refinement)
+    # create_enum :mapping_origin_type,
+    #   %w(see_target see_source test dg_link_verif dg_implies_link
+    #      dg_link_extension dg_link_translation dg_link_closed_lenv
+    #      dg_link_imports dg_link_intersect dg_link_morph dg_link_inst
+    #      dg_link_inst_arg dg_link_view dg_link_align dg_link_fit_view
+    #      dg_link_fit_view_imp dg_link_proof dg_link_flattening_union
+    #      dg_link_flattening_rename dg_link_refinement)
 
-    create_enum :mapping_type_type,
-      %w(local_def local_thm_open local_thm_proved
-         global_def global_thm_open global_thm_proved
-         hiding_def
-         free_def cofree_def np_free_def minimize_def
-         hiding_open hiding_proved
-         free_open cofree_open np_free_open minimize_open
-         free_proved cofree_proved np_free_proved minimize_proved)
+    # create_enum :mapping_type_type,
+    #   %w(local_def local_thm_open local_thm_proved
+    #      global_def global_thm_open global_thm_proved
+    #      hiding_def
+    #      free_def cofree_def np_free_def minimize_def
+    #      hiding_open hiding_proved
+    #      free_open cofree_open np_free_open minimize_open
+    #      free_proved cofree_proved np_free_proved minimize_proved)
 
     create_table :mappings do
       primary_key :id, type: :bigserial
@@ -478,8 +504,12 @@ Sequel.migration do
                   null: true, on_delete: :set_null
       column :display_name, String, null: false
       column :name, String, null: false
-      column :origin, :mapping_origin_type
-      column :type, :mapping_type_type, null: false
+      # This is actually a :mapping_origin_type, but it is replaced by a String
+      # for compatibility reasons.
+      column :origin, String, collate: '"C"'
+      # This is actually a :mapping_type_type, but it is replaced by a String
+      # for compatibility reasons.
+      column :type, String, collate: '"C"', null: false
       column :pending, TrueClass, null: false
     end
 
@@ -495,9 +525,9 @@ Sequel.migration do
       column :text, String, null: false
     end
 
-    REASONING_STATUSES ||= %w(OPN ERR UNK RSO THM CSA CSAS).freeze
-    create_enum :reasoning_status_on_conjecture_type,
-      [*REASONING_STATUSES, 'CONTR']
+    # REASONING_STATUSES ||= %w(OPN ERR UNK RSO THM CSA CSAS).freeze
+    # create_enum :reasoning_status_on_conjecture_type,
+    #   [*REASONING_STATUSES, 'CONTR']
 
     create_table :axioms do
       primary_key :id, type: :bigserial
@@ -510,10 +540,14 @@ Sequel.migration do
       primary_key :id, type: :bigserial
       foreign_key [:id], :sentences,
                   null: false, unique: true, on_delete: :cascade
-      column :evaluation_state, :evaluation_state_type,
+      # This is actually a :evaluation_state_type, but replaced by String for
+      # compatibility reasons.
+      column :evaluation_state, String, collate: '"C"',
         null: false,
         default: 'not_yet_enqueued'
-      column :reasoning_status, :reasoning_status_on_conjecture_type,
+      # This is actually a :reasoning_status_on_conjecture_type, but it is
+      # replaced by a String for compatibility reasons.
+      column :reasoning_status, String, collate: '"C"',
         null: false,
         default: 'OPN'
     end
@@ -571,14 +605,16 @@ Sequel.migration do
       column :time_limit, Integer, null: true
     end
 
-    create_enum :premise_selection_kind_type,
-      %w(ManualPremiseSelection SinePremiseSelection)
+    # create_enum :premise_selection_kind_type,
+    #   %w(ManualPremiseSelection SinePremiseSelection)
 
     create_table :premise_selections do
       primary_key :id
       foreign_key :reasoner_configuration_id, :reasoner_configurations,
                   null: false, on_delete: :cascade
-      column :kind, :premise_selection_kind_type, null: false
+      # This is actually a :premise_selection_kind_type, but it is replaced by
+      # a String for compatibility reasons.
+      column :kind, String, collate: '"C"', null: false
     end
 
     create_table :premise_selected_sentences do
@@ -626,10 +662,10 @@ Sequel.migration do
       column :commonness, Integer, null: false
     end
 
-    create_enum :reasoning_attempt_kind_type,
-      %w(ProofAttempt ConsistencyCheckAttempt)
+    # create_enum :reasoning_attempt_kind_type,
+    #   %w(ProofAttempt ConsistencyCheckAttempt)
 
-    create_enum :reasoning_status_on_reasoning_attempt_type, REASONING_STATUSES
+    # create_enum :reasoning_status_on_reasoning_attempt_type, REASONING_STATUSES
 
     # ReasoningAttempt is using Single Table Inheritance
     create_table :reasoning_attempts do
@@ -639,11 +675,17 @@ Sequel.migration do
       # There is no used reasoner until reasoning has begun.
       foreign_key :used_reasoner_id, :reasoners,
                   null: true, on_delete: :set_null
-      column :kind, :reasoning_attempt_kind_type, null: false
+      # This is actually a :reasoning_attempt_kind_type, but it is replaced by
+      # a String for compatibility reasons.
+      column :kind, String, collate: '"C"', null: false
       column :time_taken, Integer, null: true
-      column :evaluation_state, :evaluation_state_type,
+      # This is actually a :evaluation_state_type, but replaced by String for
+      # compatibility reasons.
+      column :evaluation_state, String, collate: '"C"',
              null: false, default: 'not_yet_enqueued'
-      column :reasoning_status, :reasoning_status_on_reasoning_attempt_type,
+      # This is actually a :reasoning_status_on_reasoning_attempt_type, but it
+      # is replaced by a String for compatibility reasons.
+      column :reasoning_status, String, collate: '"C"',
              null: false, default: 'OPN'
 
       column :created_at, DateTime, null: false # This is set by a trigger

--- a/spec/models/file_version_spec.rb
+++ b/spec/models/file_version_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe FileVersion, type: :model do
       subject.repository = nil
       expect(subject.valid?).to be(false)
     end
+
+    it 'is valid if the evaluation_state is nil' do
+      subject.evaluation_state = nil
+      expect(subject.valid?).to be(true)
+    end
+
+    it 'is invalid if the evaluation_state is bad' do
+      subject.evaluation_state = 'bad'
+      expect(subject.valid?).to be(false)
+    end
   end
 
   context 'compatibility' do

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -8,6 +8,24 @@ RSpec.describe Mapping do
     it_behaves_like 'a loc_id_base'
   end
 
+  context 'validations' do
+    subject { build(:mapping) }
+
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+
+    it 'is invalid if the origin is bad' do
+      subject.origin = 'bad'
+      expect(subject.valid?).to be(false)
+    end
+
+    it 'is invalid if the type is bad' do
+      subject.type = 'bad'
+      expect(subject.valid?).to be(false)
+    end
+  end
+
   context 'associations' do
     subject { create(:mapping) }
 

--- a/spec/models/oms_spec.rb
+++ b/spec/models/oms_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe OMS do
     it_behaves_like 'a loc_id_base'
   end
 
+  context 'validations' do
+    subject { build(:oms) }
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+
+    it 'is invalid if the origin is bad' do
+      subject.origin = 'bad'
+      expect(subject.valid?).to be(false)
+    end
+  end
+
   context 'associations' do
     subject { create(:oms) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -373,13 +373,6 @@ RSpec.describe User, type: :model do
         end
       end
 
-      context 'query by invalid role' do
-        it 'raises a database error' do
-          expect { subject.organizations_by_role('invalid').to_a }.
-            to raise_error(Sequel::DatabaseError)
-        end
-      end
-
       context 'query by role: read' do
         it 'does not return the organization' do
           expect(subject.organizations_by_role('read').to_a).

--- a/spec/shared_examples/a_conjecture.rb
+++ b/spec/shared_examples/a_conjecture.rb
@@ -5,6 +5,22 @@ require 'rails_helper'
 RSpec.shared_examples 'a conjecture' do
   it_behaves_like 'a sentence'
 
+  context 'validations' do
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+
+    it 'is invalid if the evaluation_state is bad' do
+      subject.evaluation_state = 'bad'
+      expect(subject.valid?).to be(false)
+    end
+
+    it 'is invalid if the reasoning_status is bad' do
+      subject.reasoning_status = 'bad'
+      expect(subject.valid?).to be(false)
+    end
+  end
+
   context 'associations' do
     before { subject.save }
 

--- a/spec/shared_examples/a_reasoning_attempt.rb
+++ b/spec/shared_examples/a_reasoning_attempt.rb
@@ -3,6 +3,22 @@
 require 'rails_helper'
 
 RSpec.shared_examples 'a reasoning_attempt' do
+  context 'validations' do
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+
+    it 'is invalid if the evaluation_state is bad' do
+      subject.evaluation_state = 'bad'
+      expect(subject.valid?).to be(false)
+    end
+
+    it 'is invalid if the reasoning_status is bad' do
+      subject.reasoning_status = 'bad'
+      expect(subject.valid?).to be(false)
+    end
+  end
+
   context 'associations' do
     before { subject.save }
 


### PR DESCRIPTION
This removes the Postgres enumeration types in favour of String columns. The problem lies in https://github.com/yesodweb/persistent/issues/264 which prevents Hets from reading the enumeration-typed columns. As soon as the mentioned issue is fixed, we can go back to using the enumeration types.

Note for future development: Whenever a column is added that should hold an enumeration type, add that type in a comment. This way, transition to the enumeration types gets a lot easier.