### PR TITLE
Add git shell API keys

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -5,6 +5,8 @@ class ApiKey < Sequel::Model
   DIGEST = 'SHA256'
   SALT = 'Ontohub API Key'
 
+  plugin :single_table_inheritance, :kind
+
   plugin :devise
   devise
 
@@ -27,13 +29,13 @@ class ApiKey < Sequel::Model
     end
 
     def digest(secret, raw_key)
-      OpenSSL::HMAC.hexdigest(DIGEST, key(secret), raw_key)
+      OpenSSL::HMAC.hexdigest(self::DIGEST, key(secret), raw_key)
     end
 
     protected
 
     def key(secret)
-      generator(secret).generate_key(SALT)
+      generator(secret).generate_key(self::SALT)
     end
 
     def generator(secret)

--- a/app/models/git_shell_api_key.rb
+++ b/app/models/git_shell_api_key.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# The GitShell API key model
+class GitShellApiKey < ApiKey
+  SALT = 'GitShell API Key'
+end

--- a/app/models/hets_api_key.rb
+++ b/app/models/hets_api_key.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# The Hets API key model
+class HetsApiKey < ApiKey
+  SALT = 'Hets API Key'
+end

--- a/db/migrate/20160902111740_initial_schema.rb
+++ b/db/migrate/20160902111740_initial_schema.rb
@@ -180,8 +180,15 @@ Sequel.migration do
       column :updated_at, DateTime, null: false # This is set by a trigger
     end
 
+    # create_enum :api_key_kind_type,
+    #   %w(HetsApiKey)
+
     create_table :api_keys do
       primary_key :id
+      # Kind of record - for class table inheritance
+      # This is actually a :api_key_kind_type, but replaced by String for
+      # compatibility reasons.
+      column :kind, String, collate: '"C"', null: false
       column :key, String, null: false, unique: true
       column :comment, String, null: true
 

--- a/db/migrate/20160902111740_initial_schema.rb
+++ b/db/migrate/20160902111740_initial_schema.rb
@@ -181,7 +181,7 @@ Sequel.migration do
     end
 
     # create_enum :api_key_kind_type,
-    #   %w(HetsApiKey)
+    #   %w(GitShellApiKey HetsApiKey)
 
     create_table :api_keys do
       primary_key :id
@@ -189,11 +189,13 @@ Sequel.migration do
       # This is actually a :api_key_kind_type, but replaced by String for
       # compatibility reasons.
       column :kind, String, collate: '"C"', null: false
-      column :key, String, null: false, unique: true
+      column :key, String, null: false
       column :comment, String, null: true
 
       column :created_at, DateTime, null: false # This is set by a trigger
       column :updated_at, DateTime, null: false # This is set by a trigger
+
+      index [:kind, :key], null: false, unique: true
     end
 
     create_table :url_mappings do

--- a/spec/factories/api_keys_factory.rb
+++ b/spec/factories/api_keys_factory.rb
@@ -2,7 +2,12 @@
 
 FactoryBot.define do
   factory :api_key do
+    kind { HetsApiKey.to_s }
     key { Faker::Crypto.sha256 }
     comment { nil }
+
+    factory :hets_api_key, class: HetsApiKey do
+      kind { HetsApiKey.to_s }
+    end
   end
 end

--- a/spec/factories/api_keys_factory.rb
+++ b/spec/factories/api_keys_factory.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     factory :hets_api_key, class: HetsApiKey do
       kind { HetsApiKey.to_s }
     end
+
+    factory :git_shell_api_key, class: GitShellApiKey do
+      kind { GitShellApiKey.to_s }
+    end
   end
 end

--- a/spec/factories/public_keys_factory.rb
+++ b/spec/factories/public_keys_factory.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :public_key do
     association :user, factory: :user
-    name { Faker::Cat.unique.name }
+    name { Faker::Lorem.unique.word }
     key { 'ssh-rsa ' + Base64.strict_encode64(Faker::Crypto.sha256) }
   end
 end

--- a/spec/models/git_shell_api_key_spec.rb
+++ b/spec/models/git_shell_api_key_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GitShellApiKey do
+  context 'superclass' do
+    subject { build(:git_shell_api_key) }
+    it_behaves_like 'an ApiKey' do
+      let(:factory) { :git_shell_api_key }
+    end
+  end
+end

--- a/spec/models/hets_api_key_spec.rb
+++ b/spec/models/hets_api_key_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HetsApiKey do
+  context 'superclass' do
+    subject { build(:hets_api_key) }
+    it_behaves_like 'an ApiKey' do
+      let(:factory) { :hets_api_key }
+    end
+  end
+end

--- a/spec/shared_examples/an_api_key.rb
+++ b/spec/shared_examples/an_api_key.rb
@@ -2,16 +2,15 @@
 
 require 'rails_helper'
 
-RSpec.describe ApiKey do
+RSpec.shared_examples 'an ApiKey' do
   context 'timestamps' do
-    subject { build(:api_key) }
     it_behaves_like 'an object with timestamps'
   end
 
   context '.generate' do
     let(:secret) { Faker::Crypto.md5 }
     let(:length) { 10 }
-    let(:key) { ApiKey.generate(secret, length) }
+    let(:key) { described_class.generate(secret, length) }
 
     it 'contains an encoded and a raw key' do
       expect(key).to match(encoded: be_present, raw: be_present)
@@ -35,18 +34,18 @@ RSpec.describe ApiKey do
   context '.verify' do
     let(:secret) { Faker::Crypto.md5 }
     let(:length) { 10 }
-    let(:key) { ApiKey.generate(secret, length) }
-    let!(:api_key) { create(:api_key, key: key[:encoded]) }
+    let(:key) { described_class.generate(secret, length) }
+    let!(:api_key) { create(factory, key: key[:encoded]) }
 
     shared_examples 'it is invalid' do
       it 'does not verify' do
-        expect(ApiKey.verify(user_secret, user_key)).to be(nil)
+        expect(described_class.verify(user_secret, user_key)).to be(nil)
       end
     end
 
     shared_examples 'it is valid' do
       it 'validates' do
-        expect(ApiKey.verify(user_secret, user_key)).to eq(api_key)
+        expect(described_class.verify(user_secret, user_key)).to eq(api_key)
       end
     end
 


### PR DESCRIPTION
This adds API keys for the GitShell. The intention is that only the git-shell may check for push/pull permissions.