### PR TITLE
Add used_sentences association to ProofAttempt.

### DIFF
--- a/app/models/proof_attempt.rb
+++ b/app/models/proof_attempt.rb
@@ -6,6 +6,11 @@ class ProofAttempt < ReasoningAttempt
 
   many_to_one :conjecture, class: Conjecture
 
+  many_to_many :used_sentences, join_table: :proof_attempts_used_sentences,
+                                left_key: :proof_attempt_id,
+                                right_key: :sentence_id,
+                                class: Sentence
+
   # Equivalent to conjecture.repository
   one_to_one :repository, dataset: (proc do |reflection|
     reflection.associated_dataset.

--- a/db/migrate/20160902111740_initial_schema.rb
+++ b/db/migrate/20160902111740_initial_schema.rb
@@ -734,6 +734,14 @@ Sequel.migration do
     create_trigger_to_delete_parent(:consistency_check_attempts,
                                     :reasoning_attempts)
 
+    create_table :proof_attempts_used_sentences do
+      primary_key :id
+      foreign_key :proof_attempt_id, :proof_attempts,
+                  type: :bigint, null: false, on_delete: :cascade
+      foreign_key :sentence_id, :sentences,
+                  type: :bigint, null: false, on_delete: :cascade
+    end
+
     create_table :generated_axioms do
       primary_key :id
       foreign_key :reasoning_attempt_id, :reasoning_attempts,

--- a/spec/models/proof_attempt_spec.rb
+++ b/spec/models/proof_attempt_spec.rb
@@ -34,5 +34,23 @@ RSpec.describe ProofAttempt, type: :model do
       it_behaves_like('it has a', :repository, Repository)
       it_behaves_like('being deleted with the association', :repository)
     end
+
+    context 'used_sentences' do
+      let!(:unrelated) do
+        (1..2).map { create(:sentence) }
+      end
+
+      let!(:related) do
+        sentences = (1..2).map { create(:sentence) }
+        sentences.each do |sentence|
+          subject.add_used_sentence(sentence)
+        end
+        sentences
+      end
+
+      it 'has the used_sentences' do
+        expect(subject.used_sentences).to match_array(related)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is the models-part of https://github.com/spechub/Hets/pull/1836. We did not have a `used_sentences` association on a ProofAttempt.