### PR TITLE
Add original_sentence association to Sentence.

### DIFF
--- a/app/models/sentence.rb
+++ b/app/models/sentence.rb
@@ -6,6 +6,15 @@ class Sentence < LocIdBase
   many_to_one :file_range
   many_to_many :symbols, class: OMSSymbol, join_table: :sentences_symbols
 
+  # If this sentence is created by a mapping, this refers to the original
+  # sentence:
+  one_to_one :original_sentence, class: Sentence, dataset: (proc do |reflection|
+    # If we do not return this custom dataset, Sequel adds a where clause
+    # with a wrong column
+    reflection.associated_dataset.
+      where(Sequel[:loc_id_bases][:id] => original_sentence_id)
+  end)
+
   # Equivalent to oms.repository
   one_to_one :repository, dataset: (proc do |reflection|
     reflection.associated_dataset.

--- a/db/migrate/20160902111740_initial_schema.rb
+++ b/db/migrate/20160902111740_initial_schema.rb
@@ -588,6 +588,8 @@ Sequel.migration do
       foreign_key :oms_id, :oms, type: :bigint, null: false, on_delete: :cascade
       foreign_key :file_range_id, :file_ranges,
                   type: :bigint, null: true, on_delete: :set_null
+      foreign_key :original_sentence_id, :sentences,
+                  type: :bigint, null: true, on_delete: :set_null
       column :name, String, null: false
       column :text, String, null: false
     end

--- a/spec/factories/sentences_factory.rb
+++ b/spec/factories/sentences_factory.rb
@@ -34,5 +34,9 @@ FactoryBot.define do
         kind { Theorem.to_s }
       end
     end
+
+    trait :with_original_sentence do
+      association :original_sentence
+    end
   end
 end

--- a/spec/shared_examples/a_sentence.rb
+++ b/spec/shared_examples/a_sentence.rb
@@ -16,6 +16,17 @@ RSpec.shared_examples 'a sentence' do
       it_behaves_like('being deleted with the association', :oms)
     end
 
+    context 'original_sentence' do
+      before do
+        subject.original_sentence_id = create(:sentence).id
+        subject.save
+      end
+
+      it_behaves_like('it has a', :original_sentence, Sentence)
+      it_behaves_like('being nullified with deletion of the association',
+                      :original_sentence)
+    end
+
     it_behaves_like 'having a file_range'
 
     context 'symbols' do


### PR DESCRIPTION
This is the ontohub-models part of https://github.com/spechub/Hets/pull/1843.

If a Sentence is created by a Mapping, then it has a reference to the original Sentence.

Example: OMS O1 contains Sentence S1 and is imported by OMS O2. Then "O2 sort of contains S1", but it's not really S1. It is a new sentence that points to S1 via the `original_sentence` association.